### PR TITLE
Add Easter monday to Lithuania

### DIFF
--- a/Nager.Date/PublicHolidays/LithuaniaProvider.cs
+++ b/Nager.Date/PublicHolidays/LithuaniaProvider.cs
@@ -19,6 +19,7 @@ namespace Nager.Date.PublicHolidays
             items.Add(new PublicHoliday(year, 2, 16, "Lietuvos valstybės atkūrimo diena", "The Day of Restoration of the State of Lithuania", countryCode));
             items.Add(new PublicHoliday(year, 3, 11, "Lietuvos nepriklausomybės atkūrimo diena", "Day of Restoration of Independence of Lithuania", countryCode));
             items.Add(new PublicHoliday(easterSunday, "Velykos", "Easter Sunday", countryCode));
+            items.Add(new PublicHoliday(easterSunday.AddDays(1), "Antroji Velykų diena", "Easter Monday", countryCode));
             items.Add(new PublicHoliday(year, 5, 1, "Tarptautinė darbo diena", "International Working Day", countryCode));
             items.Add(new PublicHoliday(year, 6, 24, "Joninės, Rasos", "St. John's Day", countryCode));
             items.Add(new PublicHoliday(year, 7, 6, "Valstybės diena", "Statehood Day", countryCode));


### PR DESCRIPTION
Lithuania also has Easter Monday.

https://en.wikipedia.org/wiki/Public_holidays_in_Lithuania

> The first Sunday after the full moon that occurs on or soonest after 21 March **and following Monday**
