### PR TITLE
Fix for issue #22

### DIFF
--- a/Nager.Date.UnitTest/Nager.Date.UnitTest.csproj
+++ b/Nager.Date.UnitTest/Nager.Date.UnitTest.csproj
@@ -29,7 +29,8 @@
   <ItemGroup>
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.17" />
     <PackageReference Include="MSTest.TestFramework" Version="1.1.17" />
-  </ItemGroup>
+    <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="15.0.0" />
+  </ItemGroup>  
   
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/Nager.Date.UnitTest/UnitTestGermany.cs
+++ b/Nager.Date.UnitTest/UnitTestGermany.cs
@@ -62,13 +62,21 @@ namespace Nager.Date.UnitTest
         }
 
         [TestMethod]
-        public void TestGermanyByCounty2017()
+        public void TestGermanyIsOfficialPublicHolidayByCountyWithCountySpecificEpiphany2017()
         {
             var isPublicHolidayInBW = DateSystem.IsOfficialPublicHolidayByCounty(new DateTime(2017, 1, 6), CountryCode.DE, "DE-BW");
             var isPublicHolidayInNW = DateSystem.IsOfficialPublicHolidayByCounty(new DateTime(2017, 1, 6), CountryCode.DE, "DE-NW");
 
             Assert.IsTrue(isPublicHolidayInBW);
             Assert.IsFalse(isPublicHolidayInNW);
+        }
+
+        [TestMethod]
+        public void TestGermanyIsOfficialPublicHolidayByCountyWithGlobalChristmasDay2017()
+        {
+            var isPublicHolidayInBW = DateSystem.IsOfficialPublicHolidayByCounty(new DateTime(2017, 12, 25), CountryCode.DE, "DE-BW");
+
+            Assert.IsTrue(isPublicHolidayInBW);
         }
     }
 }

--- a/Nager.Date.UnitTest/UnitTestGermany.cs
+++ b/Nager.Date.UnitTest/UnitTestGermany.cs
@@ -65,10 +65,10 @@ namespace Nager.Date.UnitTest
         public void TestGermanyByCounty2017()
         {
             var isPublicHolidayInBW = DateSystem.IsOfficialPublicHolidayByCounty(new DateTime(2017, 1, 6), CountryCode.DE, "DE-BW");
-            var isPublicHolidayInNRW = DateSystem.IsOfficialPublicHolidayByCounty(new DateTime(2017, 1, 6), CountryCode.DE, "DE-NRW");
+            var isPublicHolidayInNW = DateSystem.IsOfficialPublicHolidayByCounty(new DateTime(2017, 1, 6), CountryCode.DE, "DE-NW");
 
             Assert.IsTrue(isPublicHolidayInBW);
-            Assert.IsFalse(isPublicHolidayInNRW);
+            Assert.IsFalse(isPublicHolidayInNW);
         }
     }
 }

--- a/Nager.Date/DateSystem.cs
+++ b/Nager.Date/DateSystem.cs
@@ -228,13 +228,13 @@ namespace Nager.Date
         public static bool IsOfficialPublicHolidayByCounty(DateTime date, CountryCode countryCode, string countyCode)
         {
             var items = GetPublicHoliday(countryCode, date.Year);
-            return items.Any(o => o.Date.Date == date.Date && o.Counties.Contains(countyCode) == true && o.CountyOfficialHoliday);
+            return items.Any(o => o.Date.Date == date.Date && (o.Counties == null || o.Counties.Contains(countyCode)) && o.CountyOfficialHoliday);
         }
 
         public static bool IsAdministrationPublicHolidayByCounty(DateTime date, CountryCode countryCode, string countyCode)
         {
             var items = GetPublicHoliday(countryCode, date.Year);
-            return items.Any(o => o.Date.Date == date.Date && o.Counties.Contains(countyCode) == true && o.CountyAdministrationHoliday);
+            return items.Any(o => o.Date.Date == date.Date && (o.Counties == null || o.Counties.Contains(countyCode)) && o.CountyAdministrationHoliday);
         }
 
         public static int FindLastDay(int year, int month, DayOfWeek day)

--- a/Nager.Date/DateSystem.cs
+++ b/Nager.Date/DateSystem.cs
@@ -228,13 +228,13 @@ namespace Nager.Date
         public static bool IsOfficialPublicHolidayByCounty(DateTime date, CountryCode countryCode, string countyCode)
         {
             var items = GetPublicHoliday(countryCode, date.Year);
-            return items.Any(o => o.Date.Date == date.Date && o.Counties.Contains(countyCode) && o.CountyOfficialHoliday);
+            return items.Any(o => o.Date.Date == date.Date && o.Counties.Contains(countyCode) == true && o.CountyOfficialHoliday);
         }
 
         public static bool IsAdministrationPublicHolidayByCounty(DateTime date, CountryCode countryCode, string countyCode)
         {
             var items = GetPublicHoliday(countryCode, date.Year);
-            return items.Any(o => o.Date.Date == date.Date && o.Counties.Contains(countyCode) && o.CountyAdministrationHoliday);
+            return items.Any(o => o.Date.Date == date.Date && o.Counties.Contains(countyCode) == true && o.CountyAdministrationHoliday);
         }
 
         public static int FindLastDay(int year, int month, DayOfWeek day)

--- a/Nager.Date/Model/PublicHoliday.cs
+++ b/Nager.Date/Model/PublicHoliday.cs
@@ -31,19 +31,8 @@ namespace Nager.Date.Model
         /// <param name="countyOfficialHoliday"></param>
         /// <param name="countyAdministrationHoliday"></param>
         public PublicHoliday(int year, int month, int day, string localName, string englishName, CountryCode countryCode, int? launchYear = null, string[] counties = null, bool countyOfficialHoliday = true, bool countyAdministrationHoliday = true)
+            : this(new DateTime(year, month, day), localName, englishName, countryCode, launchYear, counties, countyOfficialHoliday, countyAdministrationHoliday)
         {
-            this.Date = new DateTime(year, month, day);
-            this.LocalName = localName;
-            this.Name = englishName;
-            this.CountryCode = countryCode;
-            this.Fixed = true;
-            this.CountyOfficialHoliday = countyOfficialHoliday;
-            this.CountyAdministrationHoliday = countyAdministrationHoliday;
-            this.LaunchYear = launchYear;
-            if (counties?.Length > 0)
-            {
-                this.Counties = counties;
-            }
         }
 
         /// <summary>

--- a/Nager.Date/Model/PublicHoliday.cs
+++ b/Nager.Date/Model/PublicHoliday.cs
@@ -31,8 +31,19 @@ namespace Nager.Date.Model
         /// <param name="countyOfficialHoliday"></param>
         /// <param name="countyAdministrationHoliday"></param>
         public PublicHoliday(int year, int month, int day, string localName, string englishName, CountryCode countryCode, int? launchYear = null, string[] counties = null, bool countyOfficialHoliday = true, bool countyAdministrationHoliday = true)
-            : this(new DateTime(year, month, day), localName, englishName, countryCode, launchYear, counties, countyOfficialHoliday, countyAdministrationHoliday)
         {
+            this.Date = new DateTime(year, month, day);
+            this.LocalName = localName;
+            this.Name = englishName;
+            this.CountryCode = countryCode;
+            this.Fixed = true;
+            this.CountyOfficialHoliday = countyOfficialHoliday;
+            this.CountyAdministrationHoliday = countyAdministrationHoliday;
+            this.LaunchYear = launchYear;
+            if (counties?.Length > 0)
+            {
+                this.Counties = counties;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Hi Tino,

the problem was not with the county-specific public holiday (Epiphany-Day) but if you check a global public holiday with the method `IsOfficialPublicHolidayByCounty` (like Christmas-Day).

In that case the Counties `string[]` is null and the `Any()` LINQ expression will fail with an`ArgumentNullException`

![bildschirmfoto 2017-05-07 um 14 38 12](https://cloud.githubusercontent.com/assets/575109/25780985/da64a9a0-3332-11e7-9df0-0a596eea7745.png)

I've updated bot methods `IsOfficialPublicHolidayByCounty` and `IsAdministrationPublicHolidayByCounty` to respect that Counties might be null in case of global public holiday.

Cheers,
Marcus
