### PR TITLE
Fixed LocalNames for German Christmas Holidays

### DIFF
--- a/Src/Nager.Date/PublicHolidays/GermanyProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/GermanyProvider.cs
@@ -32,7 +32,7 @@ namespace Nager.Date.PublicHolidays
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Germany
-            //https://en.wikipedia.org/wiki/Public_holidays_in_Germany
+            // https://de.wikipedia.org/wiki/Gesetzliche_Feiertage_in_Deutschland
 
             var countryCode = CountryCode.DE;
             var easterSunday = base.EasterSunday(year);
@@ -49,8 +49,8 @@ namespace Nager.Date.PublicHolidays
             items.Add(new PublicHoliday(year, 8, 15, "Mariä Himmelfahrt", "Assumption Day", countryCode, null, new string[] { "DE-SL" }));
             items.Add(new PublicHoliday(year, 10, 3, "Tag der Deutschen Einheit", "German Unity Day", countryCode));
             items.Add(new PublicHoliday(year, 11, 1, "Allerheiligen", "All Saints' Day", countryCode, null, new string[] { "DE-BW", "DE-BY", "DE-NW", "DE-RP", "DE-SL" }));
-            items.Add(new PublicHoliday(year, 12, 25, "Weihnachten", "Christmas Day", countryCode));
-            items.Add(new PublicHoliday(year, 12, 26, "Stefanitag", "St. Stephen's Day", countryCode));
+            items.Add(new PublicHoliday(year, 12, 25, "Erster Weihnachtstag", "Christmas Day", countryCode));
+            items.Add(new PublicHoliday(year, 12, 26, "Zweiter Weihnachtstag", "St. Stephen's Day", countryCode));
 
             var prayerDay = GetPrayerDay(year, countryCode);
             if (prayerDay != null)


### PR DESCRIPTION
December 24th is/would be what's called 'Weihnachten' in Germany, Dec 25th however is 'Erster Weihnachts(feier)tag' and Dec 26th is 'Zweiter Weihnachts(feier)tag'. I opted for the somewhat more commonly used 'Weihnachtstag'.

See also
- https://de.wikipedia.org/wiki/Gesetzliche_Feiertage_in_Deutschland
- https://www.innenministerium.bayern.de/suk/bayern/feiertage/
- https://innen.hessen.de/buerger-staat/gesetzliche-feiertage
- etc..