### PR TITLE
#72 Good Friday in hungary

### DIFF
--- a/Src/Nager.Date.UnitTest/Country/HungaryTest.cs
+++ b/Src/Nager.Date.UnitTest/Country/HungaryTest.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Nager.Date.UnitTest.Country
+{
+    [TestClass]
+    public class HungaryTest
+    {
+        [TestMethod]
+        public void TestHungary()
+        {
+            var publicHolidays = DateSystem.GetPublicHoliday(CountryCode.HU, 2018).ToArray();
+
+            //New Year's Day
+            Assert.AreEqual(new DateTime(2018, 1, 1), publicHolidays[0].Date);
+            //1848 Revolution Memorial Day
+            Assert.AreEqual(new DateTime(2018, 3, 15), publicHolidays[1].Date);
+            //Good Friday
+            Assert.AreEqual(new DateTime(2018, 3, 30), publicHolidays[2].Date);
+            //Easter Sunday
+            Assert.AreEqual(new DateTime(2018, 4, 1), publicHolidays[3].Date);
+            //Easter Monday
+            Assert.AreEqual(new DateTime(2018, 4, 2), publicHolidays[4].Date);
+            //Labour day
+            Assert.AreEqual(new DateTime(2018, 5, 1), publicHolidays[5].Date);
+            //Pentecost
+            Assert.AreEqual(new DateTime(2018, 5, 20), publicHolidays[6].Date);
+            //Whit Monday
+            Assert.AreEqual(new DateTime(2018, 5, 21), publicHolidays[7].Date);
+            //State Foundation Day
+            Assert.AreEqual(new DateTime(2018, 8, 20), publicHolidays[8].Date);
+            //1956 Revolution Memorial Day
+            Assert.AreEqual(new DateTime(2018, 10, 23), publicHolidays[9].Date);
+            //All Saints Day
+            Assert.AreEqual(new DateTime(2018, 11, 1), publicHolidays[10].Date);
+            //Christmas Day
+            Assert.AreEqual(new DateTime(2018, 12, 25), publicHolidays[11].Date);
+            //St. Stephen's Day
+            Assert.AreEqual(new DateTime(2018, 12, 26), publicHolidays[12].Date);
+        }
+    }
+}

--- a/Src/Nager.Date.UnitTest/Nager.Date.UnitTest.csproj
+++ b/Src/Nager.Date.UnitTest/Nager.Date.UnitTest.csproj
@@ -56,6 +56,7 @@
     <Compile Include="Country\GermanyTest.cs" />
     <Compile Include="Common\LogicTest.cs" />
     <Compile Include="Common\LongWeekendTest.cs" />
+    <Compile Include="Country\HungaryTest.cs" />
     <Compile Include="MockProvider.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Country\PuertoRicoTest.cs" />

--- a/Src/Nager.Date/PublicHolidays/HungaryProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/HungaryProvider.cs
@@ -11,12 +11,13 @@ namespace Nager.Date.PublicHolidays
             //Hungary
             //https://en.wikipedia.org/wiki/Public_holidays_in_Hungary
 
-            var countryCode = CountryCode.EE;
+            var countryCode = CountryCode.HU;
             var easterSunday = base.EasterSunday(year);
 
             var items = new List<PublicHoliday>();
             items.Add(new PublicHoliday(year, 1, 1, "Újév", "New Year's Day", countryCode));
             items.Add(new PublicHoliday(year, 3, 15, "Nemzeti ünnep", "1848 Revolution Memorial Day", countryCode));
+            items.Add(new PublicHoliday(easterSunday.AddDays(-2), "Jó péntek", "Good Friday", countryCode));
             items.Add(new PublicHoliday(easterSunday, "Húsvétvasárnap", "Easter Sunday", countryCode));
             items.Add(new PublicHoliday(easterSunday.AddDays(1), "Húsvéthétfő", "Easter Monday", countryCode));
             items.Add(new PublicHoliday(year, 5, 1, "A munka ünnepe", "Labour day", countryCode));

--- a/Src/Nager.Date/PublicHolidays/HungaryProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/HungaryProvider.cs
@@ -17,7 +17,7 @@ namespace Nager.Date.PublicHolidays
             var items = new List<PublicHoliday>();
             items.Add(new PublicHoliday(year, 1, 1, "Újév", "New Year's Day", countryCode));
             items.Add(new PublicHoliday(year, 3, 15, "Nemzeti ünnep", "1848 Revolution Memorial Day", countryCode));
-            items.Add(new PublicHoliday(easterSunday.AddDays(-2), "Jó péntek", "Good Friday", countryCode));
+            items.Add(new PublicHoliday(easterSunday.AddDays(-2), "Nagypéntek", "Good Friday", countryCode));
             items.Add(new PublicHoliday(easterSunday, "Húsvétvasárnap", "Easter Sunday", countryCode));
             items.Add(new PublicHoliday(easterSunday.AddDays(1), "Húsvéthétfő", "Easter Monday", countryCode));
             items.Add(new PublicHoliday(year, 5, 1, "A munka ünnepe", "Labour day", countryCode));


### PR DESCRIPTION
This pull request contains:

1. Good friday as a holiday as it is declared as a holiday since 2017.
Reference link: [Public holidays in hungary](https://en.wikipedia.org/wiki/Public_holidays_in_Hungary)

2. Updated country code of Hungary from **EE** to **HU**.
Reference link: [Hungary country code](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#HU)

3. Added unit tests for Hungary public holidays(For year 2018). Tests for all public holidays are passing successfully.