### PR TITLE
Add DateTimeExtension.IsWeekend implementation

### DIFF
--- a/Src/Nager.Date.UnitTest/Common/LogicTest.cs
+++ b/Src/Nager.Date.UnitTest/Common/LogicTest.cs
@@ -10,7 +10,7 @@ namespace Nager.Date.UnitTest.Common
         [TestMethod]
         public void CheckEasterSunday()
         {
-            var catholicProvider = new MockProvider();
+            var catholicProvider = new MockPublicHolidayProvider();
 
             var easterSunday = catholicProvider.EasterSunday(1900);
             Assert.AreEqual(new DateTime(1900, 4, 15), easterSunday);

--- a/Src/Nager.Date.UnitTest/Country/AustriaTest.cs
+++ b/Src/Nager.Date.UnitTest/Country/AustriaTest.cs
@@ -1,6 +1,7 @@
-﻿using System;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Nager.Date.Extensions;
+using System;
 using System.Linq;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Nager.Date.UnitTest.Country
 {
@@ -38,6 +39,26 @@ namespace Nager.Date.UnitTest.Country
             Assert.AreEqual(new DateTime(2017, 12, 25), publicHolidays[11].Date);
             //St. Stephen's Day
             Assert.AreEqual(new DateTime(2017, 12, 26), publicHolidays[12].Date);
+        }
+
+        [TestMethod]
+        [DataRow(2018, 10, 8, false)]
+        [DataRow(2018, 10, 9, false)]
+        [DataRow(2018, 10, 10, false)]
+        [DataRow(2018, 10, 11, false)]
+        [DataRow(2018, 10, 12, false)]
+        [DataRow(2018, 10, 13, true)]
+        [DataRow(2018, 10, 14, true)]
+        public void ChecksThatUniversalWeekendIsUsed(int year, int month, int day, bool expected)
+        {
+            // Arrange
+            var date = new DateTime(year, month, day);
+
+            // Act
+            var result = date.IsWeekend(CountryCode.AT);
+
+            // Assert
+            Assert.AreEqual(expected, result);
         }
     }
 }

--- a/Src/Nager.Date.UnitTest/Country/ChinaTest.cs
+++ b/Src/Nager.Date.UnitTest/Country/ChinaTest.cs
@@ -1,6 +1,7 @@
-﻿using System;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Nager.Date.Extensions;
+using System;
 using System.Linq;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Nager.Date.UnitTest.Country
 {
@@ -36,7 +37,7 @@ namespace Nager.Date.UnitTest.Country
         public void TestChina2017()
         {
             var publicHolidays = DateSystem.GetPublicHoliday(CountryCode.CN, 2017).ToArray();
-            var test1 = publicHolidays.Where(o=>o.Date == new DateTime(2017, 10, 4) && o.Name == "Mid-Autumn Festival").Any();
+            var test1 = publicHolidays.Where(o => o.Date == new DateTime(2017, 10, 4) && o.Name == "Mid-Autumn Festival").Any();
             var test2 = publicHolidays.Where(o => o.Date == new DateTime(2017, 4, 4) && o.Name == "Qingming Festival (Tomb-Sweeping Day)").Any();
 
             //Set to warning till china provider is fixed
@@ -81,6 +82,26 @@ namespace Nager.Date.UnitTest.Country
             {
                 Assert.Inconclusive("China provider have problems");
             }
+        }
+
+        [TestMethod]
+        [DataRow(2018, 10, 8, false)]
+        [DataRow(2018, 10, 9, false)]
+        [DataRow(2018, 10, 10, false)]
+        [DataRow(2018, 10, 11, false)]
+        [DataRow(2018, 10, 12, false)]
+        [DataRow(2018, 10, 13, true)]
+        [DataRow(2018, 10, 14, true)]
+        public void ChecksThatUniversalWeekendIsUsed(int year, int month, int day, bool expected)
+        {
+            // Arrange
+            var date = new DateTime(year, month, day);
+
+            // Act
+            var result = date.IsWeekend(CountryCode.CN);
+
+            // Assert
+            Assert.AreEqual(expected, result);
         }
     }
 }

--- a/Src/Nager.Date.UnitTest/Country/GermanyTest.cs
+++ b/Src/Nager.Date.UnitTest/Country/GermanyTest.cs
@@ -1,7 +1,7 @@
-﻿using System;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Nager.Date.Extensions;
+using System;
 using System.Linq;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Nager.Date.PublicHolidays;
 
 namespace Nager.Date.UnitTest.Country
 {
@@ -55,6 +55,26 @@ namespace Nager.Date.UnitTest.Country
             var isPublicHolidayInBW = DateSystem.IsOfficialPublicHolidayByCounty(new DateTime(2017, 12, 25), CountryCode.DE, "DE-BW");
 
             Assert.IsTrue(isPublicHolidayInBW);
+        }
+
+        [TestMethod]
+        [DataRow(2018, 10, 8, false)]
+        [DataRow(2018, 10, 9, false)]
+        [DataRow(2018, 10, 10, false)]
+        [DataRow(2018, 10, 11, false)]
+        [DataRow(2018, 10, 12, false)]
+        [DataRow(2018, 10, 13, true)]
+        [DataRow(2018, 10, 14, true)]
+        public void ChecksThatUniversalWeekendIsUsed(int year, int month, int day, bool expected)
+        {
+            // Arrange
+            var date = new DateTime(year, month, day);
+
+            // Act
+            var result = date.IsWeekend(CountryCode.DE);
+
+            // Assert
+            Assert.AreEqual(expected, result);
         }
     }
 }

--- a/Src/Nager.Date.UnitTest/Country/GermanyTest.cs
+++ b/Src/Nager.Date.UnitTest/Country/GermanyTest.cs
@@ -12,7 +12,7 @@ namespace Nager.Date.UnitTest.Country
         public void TestGermanyCorpusChristi()
         {
             var yearToTest = 2017;
-            var catholicProvider = new MockProvider();
+            var catholicProvider = new MockPublicHolidayProvider();
             var publicHolidays = DateSystem.GetPublicHoliday(CountryCode.DE, yearToTest);
             var easterSunday = catholicProvider.EasterSunday(yearToTest);
             var corpusChristi = publicHolidays.First(x => x.LocalName == "Fronleichnam").Date;

--- a/Src/Nager.Date.UnitTest/Country/HungaryTest.cs
+++ b/Src/Nager.Date.UnitTest/Country/HungaryTest.cs
@@ -1,9 +1,7 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Nager.Date.Extensions;
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Nager.Date.UnitTest.Country
 {
@@ -41,6 +39,26 @@ namespace Nager.Date.UnitTest.Country
             Assert.AreEqual(new DateTime(2018, 12, 25), publicHolidays[11].Date);
             //St. Stephen's Day
             Assert.AreEqual(new DateTime(2018, 12, 26), publicHolidays[12].Date);
+        }
+
+        [TestMethod]
+        [DataRow(2018, 10, 8, false)]
+        [DataRow(2018, 10, 9, false)]
+        [DataRow(2018, 10, 10, false)]
+        [DataRow(2018, 10, 11, false)]
+        [DataRow(2018, 10, 12, false)]
+        [DataRow(2018, 10, 13, true)]
+        [DataRow(2018, 10, 14, true)]
+        public void ChecksThatUniversalWeekendIsUsed(int year, int month, int day, bool expected)
+        {
+            // Arrange
+            var date = new DateTime(year, month, day);
+
+            // Act
+            var result = date.IsWeekend(CountryCode.HU);
+
+            // Assert
+            Assert.AreEqual(expected, result);
         }
     }
 }

--- a/Src/Nager.Date.UnitTest/Country/MexicoTest.cs
+++ b/Src/Nager.Date.UnitTest/Country/MexicoTest.cs
@@ -1,37 +1,27 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Nager.Date.Extensions;
 using System;
-using System.Linq;
 
 namespace Nager.Date.UnitTest.Country
 {
     [TestClass]
-    public class CanadaTest
+    public class MexicoTest
     {
-        [TestMethod]
-        public void TestCanada()
-        {
-            var publicHolidays = DateSystem.GetPublicHoliday(CountryCode.CA, 2017).ToArray();
-
-            //New Year's Day
-            Assert.AreEqual(new DateTime(2017, 1, 1), publicHolidays[0].Date);
-        }
-
         [TestMethod]
         [DataRow(2018, 10, 8, false)]
         [DataRow(2018, 10, 9, false)]
         [DataRow(2018, 10, 10, false)]
         [DataRow(2018, 10, 11, false)]
         [DataRow(2018, 10, 12, false)]
-        [DataRow(2018, 10, 13, true)]
+        [DataRow(2018, 10, 13, false)]
         [DataRow(2018, 10, 14, true)]
-        public void ChecksThatUniversalWeekendIsUsed(int year, int month, int day, bool expected)
+        public void ChecksThatSundayOnlyWeekendIsUsed(int year, int month, int day, bool expected)
         {
             // Arrange
             var date = new DateTime(year, month, day);
 
             // Act
-            var result = date.IsWeekend(CountryCode.CA);
+            var result = date.IsWeekend(CountryCode.MX);
 
             // Assert
             Assert.AreEqual(expected, result);

--- a/Src/Nager.Date.UnitTest/Country/PuertoRicoTest.cs
+++ b/Src/Nager.Date.UnitTest/Country/PuertoRicoTest.cs
@@ -15,7 +15,7 @@ namespace Nager.Date.UnitTest.Country
         {
             var holidays = DateSystem.GetPublicHoliday(CountryCode.PR, 2017);
 
-            var catholic = new MockProvider();
+            var catholic = new MockPublicHolidayProvider();
             var expectedGoodFriday = catholic.EasterSunday(2017).AddDays(-2);
 
             var goodFriday = holidays.First(h => h.Name == "Good Friday");

--- a/Src/Nager.Date.UnitTest/Country/PuertoRicoTest.cs
+++ b/Src/Nager.Date.UnitTest/Country/PuertoRicoTest.cs
@@ -1,6 +1,8 @@
 ﻿
-using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Nager.Date.Extensions;
+using System;
+using System.Linq;
 
 namespace Nager.Date.UnitTest.Country
 {
@@ -12,13 +14,33 @@ namespace Nager.Date.UnitTest.Country
         public void PuertoRicoHasGoodFridayHoliday()
         {
             var holidays = DateSystem.GetPublicHoliday(CountryCode.PR, 2017);
-            
+
             var catholic = new MockProvider();
             var expectedGoodFriday = catholic.EasterSunday(2017).AddDays(-2);
 
             var goodFriday = holidays.First(h => h.Name == "Good Friday");
             Assert.IsNotNull(goodFriday);
             Assert.AreEqual(expectedGoodFriday.Day, goodFriday.Date.Day);
+        }
+
+        [TestMethod]
+        [DataRow(2018, 10, 8, false)]
+        [DataRow(2018, 10, 9, false)]
+        [DataRow(2018, 10, 10, false)]
+        [DataRow(2018, 10, 11, false)]
+        [DataRow(2018, 10, 12, false)]
+        [DataRow(2018, 10, 13, true)]
+        [DataRow(2018, 10, 14, true)]
+        public void ChecksThatUniversalWeekendIsUsed(int year, int month, int day, bool expected)
+        {
+            // Arrange
+            var date = new DateTime(year, month, day);
+
+            // Act
+            var result = date.IsWeekend(CountryCode.PR);
+
+            // Assert
+            Assert.AreEqual(expected, result);
         }
     }
 }

--- a/Src/Nager.Date.UnitTest/Country/SpainTest.cs
+++ b/Src/Nager.Date.UnitTest/Country/SpainTest.cs
@@ -1,6 +1,7 @@
-﻿using System;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Nager.Date.Extensions;
+using System;
 using System.Linq;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Nager.Date.UnitTest.Country
 {
@@ -15,6 +16,26 @@ namespace Nager.Date.UnitTest.Country
                 var publicHolidays = DateSystem.GetPublicHoliday(CountryCode.ES, year);
                 Assert.AreEqual(35, publicHolidays.Count());
             }
+        }
+
+        [TestMethod]
+        [DataRow(2018, 10, 8, false)]
+        [DataRow(2018, 10, 9, false)]
+        [DataRow(2018, 10, 10, false)]
+        [DataRow(2018, 10, 11, false)]
+        [DataRow(2018, 10, 12, false)]
+        [DataRow(2018, 10, 13, true)]
+        [DataRow(2018, 10, 14, true)]
+        public void ChecksThatUniversalWeekendIsUsed(int year, int month, int day, bool expected)
+        {
+            // Arrange
+            var date = new DateTime(year, month, day);
+
+            // Act
+            var result = date.IsWeekend(CountryCode.ES);
+
+            // Assert
+            Assert.AreEqual(expected, result);
         }
     }
 }

--- a/Src/Nager.Date.UnitTest/Country/SwitzerlandTest.cs
+++ b/Src/Nager.Date.UnitTest/Country/SwitzerlandTest.cs
@@ -1,6 +1,7 @@
-﻿using System;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Nager.Date.Extensions;
+using System;
 using System.Linq;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Nager.Date.UnitTest.Country
 {
@@ -15,6 +16,26 @@ namespace Nager.Date.UnitTest.Country
                 var publicHolidays = DateSystem.GetPublicHoliday(CountryCode.CH, year);
                 Assert.AreEqual(18, publicHolidays.Count());
             }
+        }
+
+        [TestMethod]
+        [DataRow(2018, 10, 8, false)]
+        [DataRow(2018, 10, 9, false)]
+        [DataRow(2018, 10, 10, false)]
+        [DataRow(2018, 10, 11, false)]
+        [DataRow(2018, 10, 12, false)]
+        [DataRow(2018, 10, 13, true)]
+        [DataRow(2018, 10, 14, true)]
+        public void ChecksThatUniversalWeekendIsUsed(int year, int month, int day, bool expected)
+        {
+            // Arrange
+            var date = new DateTime(year, month, day);
+
+            // Act
+            var result = date.IsWeekend(CountryCode.CH);
+
+            // Assert
+            Assert.AreEqual(expected, result);
         }
     }
 }

--- a/Src/Nager.Date.UnitTest/Country/TurkeyTest.cs
+++ b/Src/Nager.Date.UnitTest/Country/TurkeyTest.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Nager.Date.Extensions;
 using System;
 using System.Linq;
 
@@ -24,12 +25,35 @@ namespace Nager.Date.UnitTest.Country
             //Atatürk Commemoration & Youth Day
             Assert.AreEqual(new DateTime(2017, 5, 19), publicHolidays[3].Date);
 
+            //Democracy Day
+            Assert.AreEqual(new DateTime(2017, 7, 15), publicHolidays[4].Date);
+
             //Victory Day
-            Assert.AreEqual(new DateTime(2017, 8, 30), publicHolidays[4].Date);
+            Assert.AreEqual(new DateTime(2017, 8, 30), publicHolidays[5].Date);
 
             //Republic Day
-            Assert.AreEqual(new DateTime(2017, 10, 29), publicHolidays[5].Date);
+            Assert.AreEqual(new DateTime(2017, 10, 29), publicHolidays[6].Date);
 
+        }
+
+        [TestMethod]
+        [DataRow(2018, 10, 8, false)]
+        [DataRow(2018, 10, 9, false)]
+        [DataRow(2018, 10, 10, false)]
+        [DataRow(2018, 10, 11, false)]
+        [DataRow(2018, 10, 12, false)]
+        [DataRow(2018, 10, 13, true)]
+        [DataRow(2018, 10, 14, true)]
+        public void ChecksThatUniversalWeekendIsUsed(int year, int month, int day, bool expected)
+        {
+            // Arrange
+            var date = new DateTime(year, month, day);
+
+            // Act
+            var result = date.IsWeekend(CountryCode.TR);
+
+            // Assert
+            Assert.AreEqual(expected, result);
         }
     }
 }

--- a/Src/Nager.Date.UnitTest/Country/UnitedKingdomTest.cs
+++ b/Src/Nager.Date.UnitTest/Country/UnitedKingdomTest.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Nager.Date.Extensions;
 using System;
 
 namespace Nager.Date.UnitTest.Country
@@ -22,5 +23,24 @@ namespace Nager.Date.UnitTest.Country
             Assert.AreEqual(true, isPublicHoliday);
         }
 
+        [TestMethod]
+        [DataRow(2018, 10, 8, false)]
+        [DataRow(2018, 10, 9, false)]
+        [DataRow(2018, 10, 10, false)]
+        [DataRow(2018, 10, 11, false)]
+        [DataRow(2018, 10, 12, false)]
+        [DataRow(2018, 10, 13, true)]
+        [DataRow(2018, 10, 14, true)]
+        public void ChecksThatUniversalWeekendIsUsed(int year, int month, int day, bool expected)
+        {
+            // Arrange
+            var date = new DateTime(year, month, day);
+
+            // Act
+            var result = date.IsWeekend(CountryCode.US);
+
+            // Assert
+            Assert.AreEqual(expected, result);
+        }
     }
 }

--- a/Src/Nager.Date.UnitTest/DateTimeExtension/DateTimeExtension_Shift.cs
+++ b/Src/Nager.Date.UnitTest/DateTimeExtension/DateTimeExtension_Shift.cs
@@ -1,0 +1,52 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Nager.Date.Extensions;
+using System;
+
+namespace Nager.Date.UnitTest.DateTimeExtension
+{
+    [TestClass]
+    public class DateTimeExtension_Shift
+    {
+        [TestMethod]
+        [DataRow(2018, 10, 8)]
+        [DataRow(2018, 10, 9)]
+        [DataRow(2018, 10, 10)]
+        [DataRow(2018, 10, 11)]
+        [DataRow(2018, 10, 12)]
+        [DataRow(2018, 10, 13)]
+        [DataRow(2018, 10, 14)]
+        public void ShouldReturnValueIfShiftFuncIsNull(int year, int month, int day)
+        {
+            var date = new DateTime(year, month, day);
+            Assert.AreEqual(date, date.Shift(DayOfWeek.Monday, null));
+        }
+
+        [TestMethod]
+        [DataRow(2018, 10, 8, DayOfWeek.Tuesday)]
+        [DataRow(2018, 10, 9, DayOfWeek.Monday)]
+        [DataRow(2018, 10, 10, DayOfWeek.Tuesday)]
+        [DataRow(2018, 10, 11, DayOfWeek.Tuesday)]
+        [DataRow(2018, 10, 12, DayOfWeek.Tuesday)]
+        [DataRow(2018, 10, 13, DayOfWeek.Tuesday)]
+        [DataRow(2018, 10, 14, DayOfWeek.Tuesday)]
+        public void ShouldReturnValueIfProvidedDayOfWeekIsNotTheRightOne(int year, int month, int day, DayOfWeek dayOfWeek)
+        {
+            var date = new DateTime(year, month, day);
+            Assert.AreEqual(date, date.Shift(dayOfWeek, d => d.AddDays(1)));
+        }
+
+        [TestMethod]
+        [DataRow(2018, 10, 8, DayOfWeek.Monday)]
+        [DataRow(2018, 10, 9, DayOfWeek.Tuesday)]
+        [DataRow(2018, 10, 10, DayOfWeek.Wednesday)]
+        [DataRow(2018, 10, 11, DayOfWeek.Thursday)]
+        [DataRow(2018, 10, 12, DayOfWeek.Friday)]
+        [DataRow(2018, 10, 13, DayOfWeek.Saturday)]
+        [DataRow(2018, 10, 14, DayOfWeek.Sunday)]
+        public void ShouldReturnAlteredValueIfProvidedDayOfWeekIsTheRightOne(int year, int month, int day, DayOfWeek dayOfWeek)
+        {
+            var date = new DateTime(year, month, day);
+            Assert.AreEqual(date.AddDays(1), date.Shift(dayOfWeek, d => d.AddDays(1)));
+        }
+    }
+}

--- a/Src/Nager.Date.UnitTest/MockPublicHolidayProvider.cs
+++ b/Src/Nager.Date.UnitTest/MockPublicHolidayProvider.cs
@@ -5,8 +5,12 @@ using System.Collections.Generic;
 
 namespace Nager.Date.UnitTest
 {
-    public class MockProvider : CatholicBaseProvider
+    public class MockPublicHolidayProvider : CatholicBaseProvider
     {
+        public MockPublicHolidayProvider() : base(new MockWeekendProvider())
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             throw new NotImplementedException();

--- a/Src/Nager.Date.UnitTest/MockWeekendProvider.cs
+++ b/Src/Nager.Date.UnitTest/MockWeekendProvider.cs
@@ -1,0 +1,13 @@
+﻿using Nager.Date.Contract;
+using System;
+
+namespace Nager.Date.UnitTest
+{
+    public class MockWeekendProvider : IWeekendProvider
+    {
+        public bool IsWeekend(DateTime date)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Src/Nager.Date.UnitTest/Nager.Date.UnitTest.csproj
+++ b/Src/Nager.Date.UnitTest/Nager.Date.UnitTest.csproj
@@ -57,6 +57,8 @@
     <Compile Include="Common\LogicTest.cs" />
     <Compile Include="Common\LongWeekendTest.cs" />
     <Compile Include="Country\HungaryTest.cs" />
+    <Compile Include="Country\MexicoTest.cs" />
+    <Compile Include="DateTimeExtension\DateTimeExtension_Shift.cs" />
     <Compile Include="MockProvider.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Country\PuertoRicoTest.cs" />
@@ -64,6 +66,9 @@
     <Compile Include="Country\SwitzerlandTest.cs" />
     <Compile Include="Country\TurkeyTest.cs" />
     <Compile Include="Country\UnitedKingdomTest.cs" />
+    <Compile Include="Weekends\SundayOnlyProviderTest.cs" />
+    <Compile Include="Weekends\SemiUniversalWeekendProviderTest.cs" />
+    <Compile Include="Weekends\UniversalWeekendProviderTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/Src/Nager.Date.UnitTest/Nager.Date.UnitTest.csproj
+++ b/Src/Nager.Date.UnitTest/Nager.Date.UnitTest.csproj
@@ -59,7 +59,8 @@
     <Compile Include="Country\HungaryTest.cs" />
     <Compile Include="Country\MexicoTest.cs" />
     <Compile Include="DateTimeExtension\DateTimeExtension_Shift.cs" />
-    <Compile Include="MockProvider.cs" />
+    <Compile Include="MockPublicHolidayProvider.cs" />
+    <Compile Include="MockWeekendProvider.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Country\PuertoRicoTest.cs" />
     <Compile Include="Country\SpainTest.cs" />

--- a/Src/Nager.Date.UnitTest/Weekends/SemiUniversalWeekendProviderTest.cs
+++ b/Src/Nager.Date.UnitTest/Weekends/SemiUniversalWeekendProviderTest.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Nager.Date.Weekends;
+using System;
+
+namespace Nager.Date.UnitTest.Weekends
+{
+    [TestClass]
+    public class SemiUniversalWeekendProviderTest
+    {
+        [TestMethod]
+        [DataRow(2018, 10, 8, false)]
+        [DataRow(2018, 10, 9, false)]
+        [DataRow(2018, 10, 10, false)]
+        [DataRow(2018, 10, 11, false)]
+        [DataRow(2018, 10, 12, true)]
+        [DataRow(2018, 10, 13, true)]
+        [DataRow(2018, 10, 14, false)]
+        public void ReturnsTrueOnFridayOrSaturday(int year, int month, int day, bool expected)
+        {
+            // Arrange
+            var date = new DateTime(year, month, day);
+            var sut = new SemiUniversalWeekendProvider();
+
+            // Act
+            var result = sut.IsWeekend(date);
+
+            // Assert
+            Assert.AreEqual(expected, result);
+        }
+    }
+}

--- a/Src/Nager.Date.UnitTest/Weekends/SundayOnlyProviderTest.cs
+++ b/Src/Nager.Date.UnitTest/Weekends/SundayOnlyProviderTest.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Nager.Date.Weekends;
+using System;
+
+namespace Nager.Date.UnitTest.Weekends
+{
+    [TestClass]
+    public class SundayOnlyProviderTest
+    {
+        [TestMethod]
+        [DataRow(2018, 10, 8, false)]
+        [DataRow(2018, 10, 9, false)]
+        [DataRow(2018, 10, 10, false)]
+        [DataRow(2018, 10, 11, false)]
+        [DataRow(2018, 10, 12, false)]
+        [DataRow(2018, 10, 13, false)]
+        [DataRow(2018, 10, 14, true)]
+        public void ReturnsTrueOnSunday(int year, int month, int day, bool expected)
+        {
+            // Arrange
+            var date = new DateTime(year, month, day);
+            var sut = new SundayOnlyProvider();
+
+            // Act
+            var result = sut.IsWeekend(date);
+
+            // Assert
+            Assert.AreEqual(expected, result);
+        }
+    }
+}

--- a/Src/Nager.Date.UnitTest/Weekends/UniversalWeekendProviderTest.cs
+++ b/Src/Nager.Date.UnitTest/Weekends/UniversalWeekendProviderTest.cs
@@ -1,22 +1,12 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Nager.Date.Extensions;
+using Nager.Date.Weekends;
 using System;
-using System.Linq;
 
-namespace Nager.Date.UnitTest.Country
+namespace Nager.Date.UnitTest.Weekends
 {
     [TestClass]
-    public class CanadaTest
+    public class UniversalWeekendProviderTest
     {
-        [TestMethod]
-        public void TestCanada()
-        {
-            var publicHolidays = DateSystem.GetPublicHoliday(CountryCode.CA, 2017).ToArray();
-
-            //New Year's Day
-            Assert.AreEqual(new DateTime(2017, 1, 1), publicHolidays[0].Date);
-        }
-
         [TestMethod]
         [DataRow(2018, 10, 8, false)]
         [DataRow(2018, 10, 9, false)]
@@ -25,13 +15,14 @@ namespace Nager.Date.UnitTest.Country
         [DataRow(2018, 10, 12, false)]
         [DataRow(2018, 10, 13, true)]
         [DataRow(2018, 10, 14, true)]
-        public void ChecksThatUniversalWeekendIsUsed(int year, int month, int day, bool expected)
+        public void ReturnsTrueOnSaturdayOrSunday(int year, int month, int day, bool expected)
         {
             // Arrange
             var date = new DateTime(year, month, day);
+            var sut = new UniversalWeekendProvider();
 
             // Act
-            var result = date.IsWeekend(CountryCode.CA);
+            var result = sut.IsWeekend(date);
 
             // Assert
             Assert.AreEqual(expected, result);

--- a/Src/Nager.Date/Contract/IOffDaysProvider.cs
+++ b/Src/Nager.Date/Contract/IOffDaysProvider.cs
@@ -1,0 +1,6 @@
+﻿namespace Nager.Date.Contract
+{
+    public interface IOffDaysProvider : IPublicHolidayProvider, IWeekendProvider
+    {
+    }
+}

--- a/Src/Nager.Date/Contract/IWeekendProvider.cs
+++ b/Src/Nager.Date/Contract/IWeekendProvider.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Nager.Date.Contract
+{
+    public interface IWeekendProvider
+    {
+        bool IsWeekend(DateTime date);
+    }
+}

--- a/Src/Nager.Date/DateSystem.cs
+++ b/Src/Nager.Date/DateSystem.cs
@@ -1,6 +1,7 @@
 ﻿using Nager.Date.Contract;
 using Nager.Date.Model;
 using Nager.Date.PublicHolidays;
+using Nager.Date.Weekends;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -9,105 +10,101 @@ namespace Nager.Date
 {
     public static class DateSystem
     {
-        static Dictionary<CountryCode, IOffDaysProvider> _countries;
-
-        static DateSystem() //static constructor
+        static Dictionary<CountryCode, IOffDaysProvider> _countries = new Dictionary<CountryCode, IOffDaysProvider>
         {
-            _countries = new Dictionary<CountryCode, IOffDaysProvider>();
-
-            _countries.Add(CountryCode.AD, new AndorraProvider());
-            _countries.Add(CountryCode.AR, new ArgentinaProvider());
-            _countries.Add(CountryCode.AT, new AustriaProvider());
-            _countries.Add(CountryCode.AU, new AustraliaProvider());
-            _countries.Add(CountryCode.AX, new AlandProvider());
-            _countries.Add(CountryCode.BB, new BarbadosProvider());
-            _countries.Add(CountryCode.BE, new BelgiumProvider());
-            _countries.Add(CountryCode.BG, new BulgariaProvider());
-            _countries.Add(CountryCode.BO, new BoliviaProvider());
-            _countries.Add(CountryCode.BR, new BrazilProvider());
-            _countries.Add(CountryCode.BS, new BahamasProvider());
-            _countries.Add(CountryCode.BW, new BotswanaProvider());
-            _countries.Add(CountryCode.BY, new BelarusProvider());
-            _countries.Add(CountryCode.BZ, new BelizeProvider());
-            _countries.Add(CountryCode.CA, new CanadaProvider());
-            _countries.Add(CountryCode.CH, new SwitzerlandProvider());
-            _countries.Add(CountryCode.CL, new ChileProvider());
-            _countries.Add(CountryCode.CN, new ChinaProvider());
-            _countries.Add(CountryCode.CO, new ColombiaProvider());
-            _countries.Add(CountryCode.CR, new CostaRicaProvider());
-            _countries.Add(CountryCode.CU, new CubaProvider());
-            _countries.Add(CountryCode.CY, new CyprusProvider());
-            _countries.Add(CountryCode.CZ, new CzechRepublicProvider());
-            _countries.Add(CountryCode.DE, new GermanyProvider());
-            _countries.Add(CountryCode.DK, new DenmarkProvider());
-            _countries.Add(CountryCode.DO, new DominicanRepublicProvider());
-            _countries.Add(CountryCode.EC, new EcuadorProvider());
-            _countries.Add(CountryCode.EG, new EgyptProvider());
-            _countries.Add(CountryCode.EE, new EstoniaProvider());
-            _countries.Add(CountryCode.ES, new SpainProvider());
-            _countries.Add(CountryCode.FI, new FinlandProvider());
-            _countries.Add(CountryCode.FO, new FaroeIslandsProvider());
-            _countries.Add(CountryCode.FR, new FranceProvider());
-            _countries.Add(CountryCode.GA, new GabonProvider());
-            _countries.Add(CountryCode.GB, new UnitedKingdomProvider());
-            _countries.Add(CountryCode.GD, new GrenadaProvider());
-            _countries.Add(CountryCode.GL, new GreenlandProvider());
-            _countries.Add(CountryCode.GR, new GreeceProvider());
-            _countries.Add(CountryCode.GT, new GuatemalaProvider());
-            _countries.Add(CountryCode.GY, new GuyanaProvider());
-            _countries.Add(CountryCode.HN, new HondurasProvider());
-            _countries.Add(CountryCode.HR, new CroatiaProvider());
-            _countries.Add(CountryCode.HT, new HaitiProvider());
-            _countries.Add(CountryCode.HU, new HungaryProvider());
-            _countries.Add(CountryCode.IE, new IrelandProvider());
-            _countries.Add(CountryCode.IM, new IsleOfManProvider());
-            _countries.Add(CountryCode.IS, new IcelandProvider());
-            _countries.Add(CountryCode.IT, new ItalyProvider());
-            _countries.Add(CountryCode.LI, new LiechtensteinProvider());
-            _countries.Add(CountryCode.LS, new LesothoProvider());
-            _countries.Add(CountryCode.LT, new LithuaniaProvider());
-            _countries.Add(CountryCode.LU, new LuxembourgProvider());
-            _countries.Add(CountryCode.LV, new LatviaProvider());
-            _countries.Add(CountryCode.JE, new JerseyProvider());
-            _countries.Add(CountryCode.JM, new JamaicaProvider());
-            _countries.Add(CountryCode.MA, new MoroccoProvider());
-            _countries.Add(CountryCode.MC, new MonacoProvider());
-            _countries.Add(CountryCode.MD, new MoldovaProvider());
-            _countries.Add(CountryCode.MG, new MadagascarProvider());
-            _countries.Add(CountryCode.MK, new MacedoniaProvider());
-            _countries.Add(CountryCode.MT, new MaltaProvider());
-            _countries.Add(CountryCode.MZ, new MozambiqueProvider());
-            _countries.Add(CountryCode.MX, new MexicoProvider());
-            _countries.Add(CountryCode.NA, new NamibiaProvider());
-            _countries.Add(CountryCode.NI, new NicaraguaProvider());
-            _countries.Add(CountryCode.NL, new NetherlandsProvider());
-            _countries.Add(CountryCode.NO, new NorwayProvider());
-            _countries.Add(CountryCode.NZ, new NewZealandProvider());
-            _countries.Add(CountryCode.PA, new PanamaProvider());
-            _countries.Add(CountryCode.PE, new PeruProvider());
-            _countries.Add(CountryCode.PL, new PolandProvider());
-            _countries.Add(CountryCode.PR, new PuertoRicoProvider());
-            _countries.Add(CountryCode.PT, new PortugalProvider());
-            _countries.Add(CountryCode.PY, new ParaguayProvider());
-            _countries.Add(CountryCode.RO, new RomaniaProvider());
-            _countries.Add(CountryCode.RU, new RussiaProvider());
-            _countries.Add(CountryCode.SM, new SanMarinoProvider());
-            _countries.Add(CountryCode.RS, new SerbiaProvider());
-            _countries.Add(CountryCode.SI, new SloveniaProvider());
-            _countries.Add(CountryCode.SJ, new SvalbardAndJanMayenProvider());
-            _countries.Add(CountryCode.SE, new SwedenProvider());
-            _countries.Add(CountryCode.SK, new SlovakiaProvider());
-            _countries.Add(CountryCode.SR, new SurinameProvider());
-            _countries.Add(CountryCode.SV, new ElSalvadorProvider());
-            _countries.Add(CountryCode.TN, new TunisiaProvider());
-            _countries.Add(CountryCode.TR, new TurkeyProvider());
-            _countries.Add(CountryCode.UA, new UkraineProvider());
-            _countries.Add(CountryCode.VA, new VaticanCityProvider());
-            _countries.Add(CountryCode.VE, new VenezuelaProvider());
-            _countries.Add(CountryCode.US, new UnitedStatesProvider());
-            _countries.Add(CountryCode.UY, new UruguayProvider());
-            _countries.Add(CountryCode.ZA, new SouthAfricaProvider());
-        }
+            { CountryCode.AD, new AndorraProvider(new UniversalWeekendProvider()) },
+            { CountryCode.AR, new ArgentinaProvider(new UniversalWeekendProvider()) },
+            { CountryCode.AT, new AustriaProvider(new UniversalWeekendProvider()) },
+            { CountryCode.AU, new AustraliaProvider(new UniversalWeekendProvider()) },
+            { CountryCode.AX, new AlandProvider(new UniversalWeekendProvider()) },
+            { CountryCode.BB, new BarbadosProvider(new UniversalWeekendProvider()) },
+            { CountryCode.BE, new BelgiumProvider(new UniversalWeekendProvider()) },
+            { CountryCode.BG, new BulgariaProvider(new UniversalWeekendProvider()) },
+            { CountryCode.BO, new BoliviaProvider(new UniversalWeekendProvider()) },
+            { CountryCode.BR, new BrazilProvider(new UniversalWeekendProvider()) },
+            { CountryCode.BS, new BahamasProvider(new UniversalWeekendProvider()) },
+            { CountryCode.BW, new BotswanaProvider(new UniversalWeekendProvider()) },
+            { CountryCode.BY, new BelarusProvider(new UniversalWeekendProvider()) },
+            { CountryCode.BZ, new BelizeProvider(new UniversalWeekendProvider()) },
+            { CountryCode.CA, new CanadaProvider(new UniversalWeekendProvider()) },
+            { CountryCode.CH, new SwitzerlandProvider(new UniversalWeekendProvider()) },
+            { CountryCode.CL, new ChileProvider(new UniversalWeekendProvider()) },
+            { CountryCode.CN, new ChinaProvider(new UniversalWeekendProvider()) },
+            { CountryCode.CO, new ColombiaProvider(new UniversalWeekendProvider()) },
+            { CountryCode.CR, new CostaRicaProvider(new UniversalWeekendProvider()) },
+            { CountryCode.CU, new CubaProvider(new UniversalWeekendProvider()) },
+            { CountryCode.CY, new CyprusProvider(new UniversalWeekendProvider()) },
+            { CountryCode.CZ, new CzechRepublicProvider(new UniversalWeekendProvider()) },
+            { CountryCode.DE, new GermanyProvider(new UniversalWeekendProvider()) },
+            { CountryCode.DK, new DenmarkProvider(new UniversalWeekendProvider()) },
+            { CountryCode.DO, new DominicanRepublicProvider(new UniversalWeekendProvider()) },
+            { CountryCode.EC, new EcuadorProvider(new UniversalWeekendProvider()) },
+            { CountryCode.EG, new EgyptProvider(new SemiUniversalWeekendProvider()) },
+            { CountryCode.EE, new EstoniaProvider(new UniversalWeekendProvider()) },
+            { CountryCode.ES, new SpainProvider(new UniversalWeekendProvider()) },
+            { CountryCode.FI, new FinlandProvider(new UniversalWeekendProvider()) },
+            { CountryCode.FO, new FaroeIslandsProvider(new UniversalWeekendProvider()) },
+            { CountryCode.FR, new FranceProvider(new UniversalWeekendProvider()) },
+            { CountryCode.GA, new GabonProvider(new UniversalWeekendProvider()) },
+            { CountryCode.GB, new UnitedKingdomProvider(new UniversalWeekendProvider()) },
+            { CountryCode.GD, new GrenadaProvider(new UniversalWeekendProvider()) },
+            { CountryCode.GL, new GreenlandProvider(new UniversalWeekendProvider()) },
+            { CountryCode.GR, new GreeceProvider(new UniversalWeekendProvider()) },
+            { CountryCode.GT, new GuatemalaProvider(new UniversalWeekendProvider()) },
+            { CountryCode.GY, new GuyanaProvider(new UniversalWeekendProvider()) },
+            { CountryCode.HN, new HondurasProvider(new UniversalWeekendProvider()) },
+            { CountryCode.HR, new CroatiaProvider(new UniversalWeekendProvider()) },
+            { CountryCode.HT, new HaitiProvider(new UniversalWeekendProvider()) },
+            { CountryCode.HU, new HungaryProvider(new UniversalWeekendProvider()) },
+            { CountryCode.IE, new IrelandProvider(new UniversalWeekendProvider()) },
+            { CountryCode.IM, new IsleOfManProvider(new UniversalWeekendProvider()) },
+            { CountryCode.IS, new IcelandProvider(new UniversalWeekendProvider()) },
+            { CountryCode.IT, new ItalyProvider(new UniversalWeekendProvider()) },
+            { CountryCode.LI, new LiechtensteinProvider(new UniversalWeekendProvider()) },
+            { CountryCode.LS, new LesothoProvider(new UniversalWeekendProvider()) },
+            { CountryCode.LT, new LithuaniaProvider(new UniversalWeekendProvider()) },
+            { CountryCode.LU, new LuxembourgProvider(new UniversalWeekendProvider()) },
+            { CountryCode.LV, new LatviaProvider(new UniversalWeekendProvider()) },
+            { CountryCode.JE, new JerseyProvider(new UniversalWeekendProvider()) },
+            { CountryCode.JM, new JamaicaProvider(new UniversalWeekendProvider()) },
+            { CountryCode.MA, new MoroccoProvider(new UniversalWeekendProvider()) },
+            { CountryCode.MC, new MonacoProvider(new UniversalWeekendProvider()) },
+            { CountryCode.MD, new MoldovaProvider(new UniversalWeekendProvider()) },
+            { CountryCode.MG, new MadagascarProvider(new UniversalWeekendProvider()) },
+            { CountryCode.MK, new MacedoniaProvider(new UniversalWeekendProvider()) },
+            { CountryCode.MT, new MaltaProvider(new UniversalWeekendProvider()) },
+            { CountryCode.MZ, new MozambiqueProvider(new UniversalWeekendProvider()) },
+            { CountryCode.MX, new MexicoProvider(new SundayOnlyProvider()) }, // https://en.wikipedia.org/wiki/Workweek_and_weekend#Around_the_world
+            { CountryCode.NA, new NamibiaProvider(new UniversalWeekendProvider()) },
+            { CountryCode.NI, new NicaraguaProvider(new UniversalWeekendProvider()) },
+            { CountryCode.NL, new NetherlandsProvider(new UniversalWeekendProvider()) },
+            { CountryCode.NO, new NorwayProvider(new UniversalWeekendProvider()) },
+            { CountryCode.NZ, new NewZealandProvider(new UniversalWeekendProvider()) },
+            { CountryCode.PA, new PanamaProvider(new UniversalWeekendProvider()) },
+            { CountryCode.PE, new PeruProvider(new UniversalWeekendProvider()) },
+            { CountryCode.PL, new PolandProvider(new UniversalWeekendProvider()) },
+            { CountryCode.PR, new PuertoRicoProvider(new UniversalWeekendProvider()) },
+            { CountryCode.PT, new PortugalProvider(new UniversalWeekendProvider()) },
+            { CountryCode.PY, new ParaguayProvider(new UniversalWeekendProvider()) },
+            { CountryCode.RO, new RomaniaProvider(new UniversalWeekendProvider()) },
+            { CountryCode.RU, new RussiaProvider(new UniversalWeekendProvider()) },
+            { CountryCode.SM, new SanMarinoProvider(new UniversalWeekendProvider()) },
+            { CountryCode.RS, new SerbiaProvider(new UniversalWeekendProvider()) },
+            { CountryCode.SI, new SloveniaProvider(new UniversalWeekendProvider()) },
+            { CountryCode.SJ, new SvalbardAndJanMayenProvider(new UniversalWeekendProvider()) },
+            { CountryCode.SE, new SwedenProvider(new UniversalWeekendProvider()) },
+            { CountryCode.SK, new SlovakiaProvider(new UniversalWeekendProvider()) },
+            { CountryCode.SR, new SurinameProvider(new UniversalWeekendProvider()) },
+            { CountryCode.SV, new ElSalvadorProvider(new UniversalWeekendProvider()) },
+            { CountryCode.TN, new TunisiaProvider(new UniversalWeekendProvider()) },
+            { CountryCode.TR, new TurkeyProvider(new UniversalWeekendProvider()) },
+            { CountryCode.UA, new UkraineProvider(new UniversalWeekendProvider()) },
+            { CountryCode.VA, new VaticanCityProvider(new UniversalWeekendProvider()) },
+            { CountryCode.VE, new VenezuelaProvider(new UniversalWeekendProvider()) },
+            { CountryCode.US, new UnitedStatesProvider(new UniversalWeekendProvider()) },
+            { CountryCode.UY, new UruguayProvider(new UniversalWeekendProvider()) },
+            { CountryCode.ZA, new SouthAfricaProvider(new UniversalWeekendProvider()) }
+        };
 
         public static IOffDaysProvider GetProvider(CountryCode countryCode)
         {
@@ -397,7 +394,7 @@ namespace Nager.Date
                 }
 
                 //Other LongWeekend on the same date, update the other
-                var otherItem = items.Where(o => o.StartDate.Equals(item.StartDate)).FirstOrDefault();
+                var otherItem = items.FirstOrDefault(o => o.StartDate.Equals(item.StartDate));
                 if (otherItem != null)
                 {
                     otherItem.EndDate = item.EndDate;

--- a/Src/Nager.Date/DateSystem.cs
+++ b/Src/Nager.Date/DateSystem.cs
@@ -9,11 +9,11 @@ namespace Nager.Date
 {
     public static class DateSystem
     {
-        static Dictionary<CountryCode, IPublicHolidayProvider> _countries;
+        static Dictionary<CountryCode, IOffDaysProvider> _countries;
 
         static DateSystem() //static constructor
         {
-            _countries = new Dictionary<CountryCode, IPublicHolidayProvider>();
+            _countries = new Dictionary<CountryCode, IOffDaysProvider>();
 
             _countries.Add(CountryCode.AD, new AndorraProvider());
             _countries.Add(CountryCode.AR, new ArgentinaProvider());
@@ -109,9 +109,9 @@ namespace Nager.Date
             _countries.Add(CountryCode.ZA, new SouthAfricaProvider());
         }
 
-        public static IPublicHolidayProvider GetProvider(CountryCode countryCode)
+        public static IOffDaysProvider GetProvider(CountryCode countryCode)
         {
-            _countries.TryGetValue(countryCode, out IPublicHolidayProvider provider);
+            _countries.TryGetValue(countryCode, out IOffDaysProvider provider);
             return provider;
         }
 

--- a/Src/Nager.Date/Extensions/DateTimeExtension.cs
+++ b/Src/Nager.Date/Extensions/DateTimeExtension.cs
@@ -7,15 +7,8 @@ namespace Nager.Date.Extensions
     {
         public static bool IsWeekend(this DateTime dateTime, CountryCode countryCode)
         {
-            //For feature weekend is different need countryCode
-            //https://en.wikipedia.org/wiki/Workweek_and_weekend
-
-            if (dateTime.DayOfWeek == DayOfWeek.Saturday || dateTime.DayOfWeek == DayOfWeek.Sunday)
-            {
-                return true;
-            }
-
-            return false;
+            var provider = DateSystem.GetProvider(countryCode);
+            return provider.IsWeekend(dateTime);
         }
 
         public static DateTime Shift(this DateTime value, Func<DateTime, DateTime> saturday, Func<DateTime, DateTime> sunday, Func<DateTime, DateTime> monday = null)
@@ -45,7 +38,6 @@ namespace Nager.Date.Extensions
 
         public static DateTime ShiftWeekdays(this DateTime value, Func<DateTime, DateTime> monday = null, Func<DateTime, DateTime> tuesday = null, Func<DateTime, DateTime> wednesday = null, Func<DateTime, DateTime> thursday = null, Func<DateTime, DateTime> friday = null)
         {
-            var daysOff = new List<DateTime>();
             switch (value.DayOfWeek)
             {
                 case DayOfWeek.Monday:
@@ -89,5 +81,8 @@ namespace Nager.Date.Extensions
 
             return value;
         }
+
+        public static DateTime Shift(this DateTime value, DayOfWeek dayOfWeek, Func<DateTime, DateTime> shift) =>
+            (shift != null && value.DayOfWeek == dayOfWeek) ? shift.Invoke(value) : value;
     }
 }

--- a/Src/Nager.Date/PublicHolidays/AlandProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/AlandProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Model;
+﻿using Nager.Date.Contract;
+using Nager.Date.Model;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -7,6 +8,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class AlandProvider : CatholicBaseProvider
     {
+        public AlandProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Åland

--- a/Src/Nager.Date/PublicHolidays/AndorraProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/AndorraProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Model;
+﻿using Nager.Date.Contract;
+using Nager.Date.Model;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -6,6 +7,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class AndorraProvider : CatholicBaseProvider
     {
+        public AndorraProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Andorra

--- a/Src/Nager.Date/PublicHolidays/ArgentinaProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/ArgentinaProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Model;
+﻿using Nager.Date.Contract;
+using Nager.Date.Model;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -7,6 +8,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class ArgentinaProvider : CatholicBaseProvider
     {
+        public ArgentinaProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Argentina

--- a/Src/Nager.Date/PublicHolidays/AustraliaProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/AustraliaProvider.cs
@@ -8,6 +8,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class AustraliaProvider : CatholicBaseProvider, ICountyProvider
     {
+        public AustraliaProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public IDictionary<string, string> GetCounties()
         {
             return new Dictionary<string, string>

--- a/Src/Nager.Date/PublicHolidays/AustriaProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/AustriaProvider.cs
@@ -7,6 +7,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class AustriaProvider : CatholicBaseProvider, ICountyProvider
     {
+        public AustriaProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public IDictionary<string, string> GetCounties()
         {
             return new Dictionary<string, string>

--- a/Src/Nager.Date/PublicHolidays/BahamasProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/BahamasProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Model;
+﻿using Nager.Date.Contract;
+using Nager.Date.Model;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -6,6 +7,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class BahamasProvider : CatholicBaseProvider
     {
+        public BahamasProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Bahamas

--- a/Src/Nager.Date/PublicHolidays/BarbadosProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/BarbadosProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Model;
+﻿using Nager.Date.Contract;
+using Nager.Date.Model;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -7,6 +8,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class BarbadosProvider : CatholicBaseProvider
     {
+        public BarbadosProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Barbados

--- a/Src/Nager.Date/PublicHolidays/BelarusProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/BelarusProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Model;
+﻿using Nager.Date.Contract;
+using Nager.Date.Model;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -6,6 +7,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class BelarusProvider : OrthodoxBaseProvider
     {
+        public BelarusProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Belarus
@@ -24,7 +29,7 @@ namespace Nager.Date.PublicHolidays
             items.Add(new PublicHoliday(year, 11, 7, "Дзень Кастрычніцкай рэвалюцыі", "October Revolution Day", countryCode));
             items.Add(new PublicHoliday(year, 12, 25, "Каляды каталiцкiя", "Catholic Christmas Day", countryCode));
             items.Add(new PublicHoliday(easterSunday.AddDays(9), "Радунiца", "Commemoration Day", countryCode));
-            
+
             return items.OrderBy(o => o.Date);
         }
     }

--- a/Src/Nager.Date/PublicHolidays/BelgiumProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/BelgiumProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Model;
+﻿using Nager.Date.Contract;
+using Nager.Date.Model;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -6,6 +7,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class BelgiumProvider : CatholicBaseProvider
     {
+        public BelgiumProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Belgium

--- a/Src/Nager.Date/PublicHolidays/BelizeProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/BelizeProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Extensions;
+﻿using Nager.Date.Contract;
+using Nager.Date.Extensions;
 using Nager.Date.Model;
 using System;
 using System.Collections.Generic;
@@ -8,6 +9,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class BelizeProvider : CatholicBaseProvider
     {
+        public BelizeProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Belize

--- a/Src/Nager.Date/PublicHolidays/BoliviaProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/BoliviaProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Model;
+﻿using Nager.Date.Contract;
+using Nager.Date.Model;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -6,6 +7,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class BoliviaProvider : CatholicBaseProvider
     {
+        public BoliviaProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Bolivia

--- a/Src/Nager.Date/PublicHolidays/BotswanaProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/BotswanaProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Model;
+﻿using Nager.Date.Contract;
+using Nager.Date.Model;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -7,6 +8,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class BotswanaProvider : CatholicBaseProvider
     {
+        public BotswanaProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Botswana

--- a/Src/Nager.Date/PublicHolidays/BrazilProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/BrazilProvider.cs
@@ -1,3 +1,4 @@
+using Nager.Date.Contract;
 using Nager.Date.Model;
 using System.Collections.Generic;
 using System.Linq;
@@ -6,6 +7,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class BrazilProvider : CatholicBaseProvider
     {
+        public BrazilProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Brazil
@@ -15,7 +20,7 @@ namespace Nager.Date.PublicHolidays
 
             var countryCode = CountryCode.BR;
             var items = new List<PublicHoliday>();
-            
+
             // official holidays (fixed dates)
             items.Add(new PublicHoliday(year, 1, 1, "Confraternização Universal", "New Year's Day", countryCode));
             items.Add(new PublicHoliday(year, 4, 21, "Dia de Tiradentes", "Tiradentes", countryCode));

--- a/Src/Nager.Date/PublicHolidays/BulgariaProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/BulgariaProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Model;
+﻿using Nager.Date.Contract;
+using Nager.Date.Model;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -6,6 +7,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class BulgariaProvider : OrthodoxBaseProvider
     {
+        public BulgariaProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Bulgaria

--- a/Src/Nager.Date/PublicHolidays/CanadaProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/CanadaProvider.cs
@@ -8,6 +8,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class CanadaProvider : CatholicBaseProvider, ICountyProvider
     {
+        public CanadaProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public IDictionary<string, string> GetCounties()
         {
             var items = new Dictionary<string, string>();
@@ -51,7 +55,7 @@ namespace Nager.Date.PublicHolidays
             items.Add(new PublicHoliday(thirdMondayInFebruary, "Family Day", "Family Day", countryCode, null, new string[] { "CA-AB", "CA-ON", "CA-SK" }));
             items.Add(new PublicHoliday(thirdMondayInFebruary, "Heritage Day", "Heritage Day", countryCode, null, new string[] { "CA-NS" }));
             items.Add(new PublicHoliday(year, 3, 17, "Saint Patrick's Day", "Saint Patrick's Day", countryCode, null, new string[] { "CA-NL" }));
-            items.Add(new PublicHoliday(easterSunday.AddDays(-2), "Good Friday", "Good Friday", countryCode));            
+            items.Add(new PublicHoliday(easterSunday.AddDays(-2), "Good Friday", "Good Friday", countryCode));
             items.Add(new PublicHoliday(easterSunday.AddDays(1), "Easter Monday", "Easter Monday", countryCode, null, new string[] { "CA-AB", "CA-PE" }));
             items.Add(new PublicHoliday(year, 4, 23, "Saint George's Day", "Saint George's Day", countryCode, null, new string[] { "CA-NL" }));
             items.Add(new PublicHoliday(mondayOnOrBeforeMay24, "National Patriots' Day", "National Patriots' Day", countryCode, null, new string[] { "CA-QC" }));

--- a/Src/Nager.Date/PublicHolidays/CatholicBaseProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/CatholicBaseProvider.cs
@@ -1,6 +1,5 @@
 ﻿using Nager.Date.Contract;
 using Nager.Date.Model;
-using Nager.Date.Weekends;
 using System;
 using System.Collections.Generic;
 
@@ -8,7 +7,12 @@ namespace Nager.Date.PublicHolidays
 {
     public abstract class CatholicBaseProvider : IOffDaysProvider
     {
-        protected IWeekendProvider weekendProvider = new UniversalWeekendProvider();
+        protected readonly IWeekendProvider _weekendProvider;
+
+        protected CatholicBaseProvider(IWeekendProvider weekendProvider)
+        {
+            _weekendProvider = weekendProvider ?? throw new ArgumentNullException(nameof(weekendProvider));
+        }
 
         public abstract IEnumerable<PublicHoliday> Get(int year);
 
@@ -52,6 +56,6 @@ namespace Nager.Date.PublicHolidays
         }
 
         public virtual bool IsWeekend(DateTime date) =>
-            weekendProvider.IsWeekend(date);
+            _weekendProvider.IsWeekend(date);
     }
 }

--- a/Src/Nager.Date/PublicHolidays/CatholicBaseProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/CatholicBaseProvider.cs
@@ -1,12 +1,15 @@
 ﻿using Nager.Date.Contract;
 using Nager.Date.Model;
+using Nager.Date.Weekends;
 using System;
 using System.Collections.Generic;
 
 namespace Nager.Date.PublicHolidays
 {
-    public abstract class CatholicBaseProvider : IPublicHolidayProvider
+    public abstract class CatholicBaseProvider : IOffDaysProvider
     {
+        protected IWeekendProvider weekendProvider = new UniversalWeekendProvider();
+
         public abstract IEnumerable<PublicHoliday> Get(int year);
 
         /// <summary>
@@ -47,5 +50,8 @@ namespace Nager.Date.PublicHolidays
 
             return christmasDate.AddDays(-daysToAdvent);
         }
+
+        public virtual bool IsWeekend(DateTime date) =>
+            weekendProvider.IsWeekend(date);
     }
 }

--- a/Src/Nager.Date/PublicHolidays/ChileProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/ChileProvider.cs
@@ -9,6 +9,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class ChileProvider : CatholicBaseProvider, ICountyProvider
     {
+        public ChileProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public IDictionary<string, string> GetCounties()
         {
             return new Dictionary<string, string>

--- a/Src/Nager.Date/PublicHolidays/ChinaProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/ChinaProvider.cs
@@ -1,6 +1,5 @@
 ﻿using Nager.Date.Contract;
 using Nager.Date.Model;
-using Nager.Date.Weekends;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -10,8 +9,12 @@ namespace Nager.Date.PublicHolidays
 {
     public class ChinaProvider : IOffDaysProvider
     {
-        // https://en.wikipedia.org/wiki/Workweek_and_weekend#Around_the_world
-        private readonly IWeekendProvider weekendProvider = new UniversalWeekendProvider();
+        private readonly IWeekendProvider _weekendProvider;
+
+        public ChinaProvider(IWeekendProvider weekendProvider)
+        {
+            _weekendProvider = weekendProvider ?? throw new ArgumentNullException(nameof(weekendProvider));
+        }
 
         public IEnumerable<PublicHoliday> Get(int year)
         {
@@ -48,7 +51,7 @@ namespace Nager.Date.PublicHolidays
         }
 
         public bool IsWeekend(DateTime date) =>
-            weekendProvider.IsWeekend(date);
+            _weekendProvider.IsWeekend(date);
 
         private int MoveMonth(int month, int leapMonth)
         {

--- a/Src/Nager.Date/PublicHolidays/ChinaProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/ChinaProvider.cs
@@ -1,13 +1,18 @@
 ﻿using Nager.Date.Contract;
 using Nager.Date.Model;
+using Nager.Date.Weekends;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 
 namespace Nager.Date.PublicHolidays
 {
-    public class ChinaProvider : IPublicHolidayProvider
+    public class ChinaProvider : IOffDaysProvider
     {
+        // https://en.wikipedia.org/wiki/Workweek_and_weekend#Around_the_world
+        private readonly IWeekendProvider weekendProvider = new UniversalWeekendProvider();
+
         public IEnumerable<PublicHoliday> Get(int year)
         {
             //TODO: Provider incomplete
@@ -41,6 +46,9 @@ namespace Nager.Date.PublicHolidays
 
             return items.OrderBy(o => o.Date);
         }
+
+        public bool IsWeekend(DateTime date) =>
+            weekendProvider.IsWeekend(date);
 
         private int MoveMonth(int month, int leapMonth)
         {

--- a/Src/Nager.Date/PublicHolidays/ColombiaProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/ColombiaProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Model;
+﻿using Nager.Date.Contract;
+using Nager.Date.Model;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -6,6 +7,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class ColombiaProvider : CatholicBaseProvider
     {
+        public ColombiaProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Colombia

--- a/Src/Nager.Date/PublicHolidays/ColombiaProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/ColombiaProvider.cs
@@ -11,6 +11,8 @@ namespace Nager.Date.PublicHolidays
             //Colombia
             //https://en.wikipedia.org/wiki/Public_holidays_in_Colombia
             //TODO: Check, movable holiday: when they do not fall on a Monday, these holidays are observed the following Monday.
+            //TODO: Check weekends in Colombia as they can be Universal or only sundays (in which case? how to handle that?)
+            //https://en.wikipedia.org/wiki/Workweek_and_weekend#Colombia
 
             var countryCode = CountryCode.CO;
             var easterSunday = base.EasterSunday(year);

--- a/Src/Nager.Date/PublicHolidays/CostaRicaProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/CostaRicaProvider.cs
@@ -1,5 +1,5 @@
-﻿using Nager.Date.Model;
-using System;
+﻿using Nager.Date.Contract;
+using Nager.Date.Model;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -7,6 +7,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class CostaRicaProvider : CatholicBaseProvider
     {
+        public CostaRicaProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Costa Rica

--- a/Src/Nager.Date/PublicHolidays/CroatiaProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/CroatiaProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Model;
+﻿using Nager.Date.Contract;
+using Nager.Date.Model;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -6,6 +7,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class CroatiaProvider : CatholicBaseProvider
     {
+        public CroatiaProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Croatia

--- a/Src/Nager.Date/PublicHolidays/CubaProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/CubaProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Model;
+﻿using Nager.Date.Contract;
+using Nager.Date.Model;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -6,6 +7,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class CubaProvider : CatholicBaseProvider
     {
+        public CubaProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Cuba
@@ -23,7 +28,7 @@ namespace Nager.Date.PublicHolidays
             items.Add(new PublicHoliday(year, 7, 26, "Día de la Rebeldía Nacional", "Commemoration of the Assault of the Moncada garrison", countryCode));
             items.Add(new PublicHoliday(year, 7, 27, "Conmemoración del asalto a Moncada", "Day after the Commemoration of the Assault of the Moncada garrison", countryCode));
             items.Add(new PublicHoliday(year, 10, 10, "Día de la Independencia", "Independence Day", countryCode));
-            items.Add(new PublicHoliday(year, 12, 25, "Navidad", "Christmas Day", countryCode));       
+            items.Add(new PublicHoliday(year, 12, 25, "Navidad", "Christmas Day", countryCode));
 
             return items.OrderBy(o => o.Date);
         }

--- a/Src/Nager.Date/PublicHolidays/CyprusProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/CyprusProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Model;
+﻿using Nager.Date.Contract;
+using Nager.Date.Model;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -6,6 +7,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class CyprusProvider : CatholicBaseProvider
     {
+        public CyprusProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Cyprus

--- a/Src/Nager.Date/PublicHolidays/CzechRepublicProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/CzechRepublicProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Model;
+﻿using Nager.Date.Contract;
+using Nager.Date.Model;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -6,6 +7,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class CzechRepublicProvider : CatholicBaseProvider
     {
+        public CzechRepublicProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Czech Republic

--- a/Src/Nager.Date/PublicHolidays/DenmarkProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/DenmarkProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Model;
+﻿using Nager.Date.Contract;
+using Nager.Date.Model;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -6,6 +7,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class DenmarkProvider : CatholicBaseProvider
     {
+        public DenmarkProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Denmark

--- a/Src/Nager.Date/PublicHolidays/DominicanRepublicProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/DominicanRepublicProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Model;
+﻿using Nager.Date.Contract;
+using Nager.Date.Model;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -6,6 +7,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class DominicanRepublicProvider : CatholicBaseProvider
     {
+        public DominicanRepublicProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Dominican Republic

--- a/Src/Nager.Date/PublicHolidays/EcuadorProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/EcuadorProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Model;
+﻿using Nager.Date.Contract;
+using Nager.Date.Model;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -6,6 +7,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class EcuadorProvider : CatholicBaseProvider
     {
+        public EcuadorProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Ecuador
@@ -25,7 +30,7 @@ namespace Nager.Date.PublicHolidays
             items.Add(new PublicHoliday(year, 10, 9, "Independencia de Guayaquil", "Independence of Guayaquil", countryCode));
             items.Add(new PublicHoliday(year, 11, 2, "Día de los Difuntos, Día de Muertos", "All Souls' Day", countryCode));
             items.Add(new PublicHoliday(year, 11, 3, "Independencia de Cuenca", "Independence of Cuenca", countryCode));
-            items.Add(new PublicHoliday(year, 12, 25, "Día de Navidad", "Christmas Day", countryCode));         
+            items.Add(new PublicHoliday(year, 12, 25, "Día de Navidad", "Christmas Day", countryCode));
 
             return items.OrderBy(o => o.Date);
         }

--- a/Src/Nager.Date/PublicHolidays/EgyptProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/EgyptProvider.cs
@@ -1,6 +1,5 @@
 ﻿using Nager.Date.Contract;
 using Nager.Date.Model;
-using Nager.Date.Weekends;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -9,8 +8,12 @@ namespace Nager.Date.PublicHolidays
 {
     public class EgyptProvider : IOffDaysProvider
     {
-        //https://en.wikipedia.org/wiki/Workweek_and_weekend#Around_the_world
-        private readonly IWeekendProvider weekendProvider = new SemiUniversalWeekendProvider();
+        private readonly IWeekendProvider _weekendProvider;
+
+        public EgyptProvider(IWeekendProvider weekendProvider)
+        {
+            _weekendProvider = weekendProvider ?? throw new ArgumentNullException(nameof(weekendProvider));
+        }
 
         public IEnumerable<PublicHoliday> Get(int year)
         {
@@ -39,6 +42,6 @@ namespace Nager.Date.PublicHolidays
         }
 
         public bool IsWeekend(DateTime date) =>
-            weekendProvider.IsWeekend(date);
+            _weekendProvider.IsWeekend(date);
     }
 }

--- a/Src/Nager.Date/PublicHolidays/EgyptProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/EgyptProvider.cs
@@ -1,12 +1,17 @@
 ﻿using Nager.Date.Contract;
 using Nager.Date.Model;
+using Nager.Date.Weekends;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
 namespace Nager.Date.PublicHolidays
 {
-    public class EgyptProvider : IPublicHolidayProvider
+    public class EgyptProvider : IOffDaysProvider
     {
+        //https://en.wikipedia.org/wiki/Workweek_and_weekend#Around_the_world
+        private readonly IWeekendProvider weekendProvider = new SemiUniversalWeekendProvider();
+
         public IEnumerable<PublicHoliday> Get(int year)
         {
             //Egypt
@@ -32,5 +37,8 @@ namespace Nager.Date.PublicHolidays
 
             return items.OrderBy(o => o.Date);
         }
+
+        public bool IsWeekend(DateTime date) =>
+            weekendProvider.IsWeekend(date);
     }
 }

--- a/Src/Nager.Date/PublicHolidays/ElSalvadorProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/ElSalvadorProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Model;
+﻿using Nager.Date.Contract;
+using Nager.Date.Model;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -6,6 +7,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class ElSalvadorProvider : CatholicBaseProvider
     {
+        public ElSalvadorProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //El Salvador

--- a/Src/Nager.Date/PublicHolidays/EstoniaProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/EstoniaProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Model;
+﻿using Nager.Date.Contract;
+using Nager.Date.Model;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -6,6 +7,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class EstoniaProvider : CatholicBaseProvider
     {
+        public EstoniaProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Estonia

--- a/Src/Nager.Date/PublicHolidays/FaroeIslandsProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/FaroeIslandsProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Model;
+﻿using Nager.Date.Contract;
+using Nager.Date.Model;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -6,6 +7,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class FaroeIslandsProvider : CatholicBaseProvider
     {
+        public FaroeIslandsProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Faroe Islands, adaptation of DenmarkProvider

--- a/Src/Nager.Date/PublicHolidays/FinlandProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/FinlandProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Model;
+﻿using Nager.Date.Contract;
+using Nager.Date.Model;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -7,6 +8,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class FinlandProvider : CatholicBaseProvider
     {
+        public FinlandProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Finland

--- a/Src/Nager.Date/PublicHolidays/FranceProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/FranceProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Model;
+﻿using Nager.Date.Contract;
+using Nager.Date.Model;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -6,6 +7,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class FranceProvider : CatholicBaseProvider
     {
+        public FranceProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //France

--- a/Src/Nager.Date/PublicHolidays/GabonProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/GabonProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Model;
+﻿using Nager.Date.Contract;
+using Nager.Date.Model;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -6,6 +7,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class GabonProvider : CatholicBaseProvider
     {
+        public GabonProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Gabon

--- a/Src/Nager.Date/PublicHolidays/GermanyProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/GermanyProvider.cs
@@ -7,6 +7,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class GermanyProvider : CatholicBaseProvider, ICountyProvider
     {
+        public GermanyProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public IDictionary<string, string> GetCounties()
         {
             return new Dictionary<string, string>
@@ -46,7 +50,7 @@ namespace Nager.Date.PublicHolidays
             items.Add(new PublicHoliday(year, 5, 1, "Tag der Arbeit", "Labour Day", countryCode));
             items.Add(new PublicHoliday(easterSunday.AddDays(39), "Christi Himmelfahrt", "Ascension Day", countryCode));
             items.Add(new PublicHoliday(easterSunday.AddDays(50), "Pfingstmontag", "Whit Monday", countryCode));
-            items.Add(new PublicHoliday(easterSunday.AddDays(60), "Fronleichnam", "Corpus Christi", countryCode,null, new string[] { "DE-BW", "DE-BY", "DE-HE", "DE-NW", "DE-RP", "DE-SL" }));
+            items.Add(new PublicHoliday(easterSunday.AddDays(60), "Fronleichnam", "Corpus Christi", countryCode, null, new string[] { "DE-BW", "DE-BY", "DE-HE", "DE-NW", "DE-RP", "DE-SL" }));
             items.Add(new PublicHoliday(year, 8, 15, "Mariä Himmelfahrt", "Assumption Day", countryCode, null, new string[] { "DE-SL" }));
             items.Add(new PublicHoliday(year, 10, 3, "Tag der Deutschen Einheit", "German Unity Day", countryCode));
             items.Add(new PublicHoliday(year, 11, 1, "Allerheiligen", "All Saints' Day", countryCode, null, new string[] { "DE-BW", "DE-BY", "DE-NW", "DE-RP", "DE-SL" }));

--- a/Src/Nager.Date/PublicHolidays/GreeceProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/GreeceProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Model;
+﻿using Nager.Date.Contract;
+using Nager.Date.Model;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -6,6 +7,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class GreeceProvider : OrthodoxBaseProvider
     {
+        public GreeceProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Greece

--- a/Src/Nager.Date/PublicHolidays/GreenlandProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/GreenlandProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Model;
+﻿using Nager.Date.Contract;
+using Nager.Date.Model;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -6,6 +7,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class GreenlandProvider : CatholicBaseProvider
     {
+        public GreenlandProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Greenland

--- a/Src/Nager.Date/PublicHolidays/GrenadaProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/GrenadaProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Model;
+﻿using Nager.Date.Contract;
+using Nager.Date.Model;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -7,6 +8,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class GrenadaProvider : CatholicBaseProvider
     {
+        public GrenadaProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Grenada

--- a/Src/Nager.Date/PublicHolidays/GuatemalaProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/GuatemalaProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Model;
+﻿using Nager.Date.Contract;
+using Nager.Date.Model;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -6,6 +7,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class GuatemalaProvider : CatholicBaseProvider
     {
+        public GuatemalaProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Guatemala

--- a/Src/Nager.Date/PublicHolidays/GuyanaProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/GuyanaProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Model;
+﻿using Nager.Date.Contract;
+using Nager.Date.Model;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -7,6 +8,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class GuyanaProvider : CatholicBaseProvider
     {
+        public GuyanaProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Guyana

--- a/Src/Nager.Date/PublicHolidays/HaitiProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/HaitiProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Model;
+﻿using Nager.Date.Contract;
+using Nager.Date.Model;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -6,6 +7,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class HaitiProvider : CatholicBaseProvider
     {
+        public HaitiProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Haiti
@@ -34,7 +39,7 @@ namespace Nager.Date.PublicHolidays
             items.Add(new PublicHoliday(year, 11, 2, "Jour des Morts", "All Souls' Day", countryCode));
             items.Add(new PublicHoliday(year, 11, 18, "Vertières", "Battle of Vertières Day", countryCode));
             items.Add(new PublicHoliday(year, 12, 5, "Découverte d'Haïti", "Discovery Day", countryCode));
-            items.Add(new PublicHoliday(year, 12, 25, "Noël", "Christmas Day", countryCode));          
+            items.Add(new PublicHoliday(year, 12, 25, "Noël", "Christmas Day", countryCode));
 
             return items.OrderBy(o => o.Date);
         }

--- a/Src/Nager.Date/PublicHolidays/HondurasProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/HondurasProvider.cs
@@ -1,3 +1,4 @@
+using Nager.Date.Contract;
 using Nager.Date.Model;
 using System.Collections.Generic;
 using System.Linq;
@@ -6,6 +7,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class HondurasProvider : CatholicBaseProvider
     {
+        public HondurasProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Honduras
@@ -15,7 +20,7 @@ namespace Nager.Date.PublicHolidays
             var easterSunday = base.EasterSunday(year);
 
             var items = new List<PublicHoliday>();
-            
+
             items.Add(new PublicHoliday(year, 1, 1, "New Year's Day", "New Year's Day", countryCode));
             items.Add(new PublicHoliday(year, 4, 14, "America's Day", "America's Day", countryCode));
             items.Add(new PublicHoliday(easterSunday.AddDays(-3), "Holy Thursday", "Holy Thursday", countryCode));
@@ -27,7 +32,7 @@ namespace Nager.Date.PublicHolidays
             items.Add(new PublicHoliday(year, 10, 12, "Columbus Day", "Columbus Day", countryCode));
             items.Add(new PublicHoliday(year, 10, 21, "Army Day", "Army Day", countryCode));
             items.Add(new PublicHoliday(year, 12, 25, "Navidad", "Christmas Day", countryCode));
-            
+
             return items.OrderBy(o => o.Date);
         }
     }

--- a/Src/Nager.Date/PublicHolidays/HungaryProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/HungaryProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Model;
+﻿using Nager.Date.Contract;
+using Nager.Date.Model;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -6,6 +7,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class HungaryProvider : CatholicBaseProvider
     {
+        public HungaryProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Hungary

--- a/Src/Nager.Date/PublicHolidays/IcelandProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/IcelandProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Model;
+﻿using Nager.Date.Contract;
+using Nager.Date.Model;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -7,6 +8,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class IcelandProvider : CatholicBaseProvider
     {
+        public IcelandProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Iceland

--- a/Src/Nager.Date/PublicHolidays/IrelandProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/IrelandProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Model;
+﻿using Nager.Date.Contract;
+using Nager.Date.Model;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -7,6 +8,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class IrelandProvider : CatholicBaseProvider
     {
+        public IrelandProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Ireland

--- a/Src/Nager.Date/PublicHolidays/IsleOfManProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/IsleOfManProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Model;
+﻿using Nager.Date.Contract;
+using Nager.Date.Model;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -7,6 +8,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class IsleOfManProvider : CatholicBaseProvider
     {
+        public IsleOfManProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Isle of Man

--- a/Src/Nager.Date/PublicHolidays/ItalyProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/ItalyProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Model;
+﻿using Nager.Date.Contract;
+using Nager.Date.Model;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -6,6 +7,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class ItalyProvider : CatholicBaseProvider
     {
+        public ItalyProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Italy

--- a/Src/Nager.Date/PublicHolidays/JamaicaProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/JamaicaProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Extensions;
+﻿using Nager.Date.Contract;
+using Nager.Date.Extensions;
 using Nager.Date.Model;
 using System;
 using System.Collections.Generic;
@@ -8,6 +9,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class JamaicaProvider : CatholicBaseProvider
     {
+        public JamaicaProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Jamaica
@@ -33,7 +38,7 @@ namespace Nager.Date.PublicHolidays
 
             items.Add(new PublicHoliday(year, 10, 16, "National Heroes Day", "National Heroes Day", countryCode));
             items.Add(new PublicHoliday(year, 12, 25, "Christmas Day", "Christmas Day", countryCode));
-            items.Add(new PublicHoliday(year, 12, 26, "Boxing Day", "St. Stephen's Day", countryCode));            
+            items.Add(new PublicHoliday(year, 12, 26, "Boxing Day", "St. Stephen's Day", countryCode));
 
             return items.OrderBy(o => o.Date);
         }

--- a/Src/Nager.Date/PublicHolidays/JerseyProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/JerseyProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Model;
+﻿using Nager.Date.Contract;
+using Nager.Date.Model;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -7,6 +8,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class JerseyProvider : CatholicBaseProvider
     {
+        public JerseyProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Jersey

--- a/Src/Nager.Date/PublicHolidays/LatviaProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/LatviaProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Model;
+﻿using Nager.Date.Contract;
+using Nager.Date.Model;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -7,6 +8,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class LatviaProvider : CatholicBaseProvider
     {
+        public LatviaProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Latvia

--- a/Src/Nager.Date/PublicHolidays/LesothoProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/LesothoProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Model;
+﻿using Nager.Date.Contract;
+using Nager.Date.Model;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -6,6 +7,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class LesothoProvider : CatholicBaseProvider
     {
+        public LesothoProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Lesotho

--- a/Src/Nager.Date/PublicHolidays/LiechtensteinProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/LiechtensteinProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Model;
+﻿using Nager.Date.Contract;
+using Nager.Date.Model;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -6,6 +7,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class LiechtensteinProvider : CatholicBaseProvider
     {
+        public LiechtensteinProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Liechtenstein

--- a/Src/Nager.Date/PublicHolidays/LithuaniaProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/LithuaniaProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Model;
+﻿using Nager.Date.Contract;
+using Nager.Date.Model;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -6,6 +7,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class LithuaniaProvider : CatholicBaseProvider
     {
+        public LithuaniaProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Lithuania

--- a/Src/Nager.Date/PublicHolidays/LuxembourgProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/LuxembourgProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Model;
+﻿using Nager.Date.Contract;
+using Nager.Date.Model;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -6,6 +7,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class LuxembourgProvider : CatholicBaseProvider
     {
+        public LuxembourgProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Luxembourg

--- a/Src/Nager.Date/PublicHolidays/MacedoniaProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/MacedoniaProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Model;
+﻿using Nager.Date.Contract;
+using Nager.Date.Model;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -6,6 +7,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class MacedoniaProvider : OrthodoxBaseProvider
     {
+        public MacedoniaProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Macedonia

--- a/Src/Nager.Date/PublicHolidays/MadagascarProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/MadagascarProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Model;
+﻿using Nager.Date.Contract;
+using Nager.Date.Model;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -6,6 +7,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class MadagascarProvider : CatholicBaseProvider
     {
+        public MadagascarProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Madagascar

--- a/Src/Nager.Date/PublicHolidays/MaltaProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/MaltaProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Model;
+﻿using Nager.Date.Contract;
+using Nager.Date.Model;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -6,6 +7,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class MaltaProvider : CatholicBaseProvider
     {
+        public MaltaProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Malta

--- a/Src/Nager.Date/PublicHolidays/MexicoProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/MexicoProvider.cs
@@ -1,5 +1,6 @@
 ﻿using Nager.Date.Extensions;
 using Nager.Date.Model;
+using Nager.Date.Weekends;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -8,6 +9,12 @@ namespace Nager.Date.PublicHolidays
 {
     public class MexicoProvider : CatholicBaseProvider
     {
+        public MexicoProvider()
+        {
+            //https://en.wikipedia.org/wiki/Workweek_and_weekend#Around_the_world
+            weekendProvider = new SundayOnlyProvider();
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Mexico (Only Statutory holidays)
@@ -39,5 +46,8 @@ namespace Nager.Date.PublicHolidays
 
             return items.OrderBy(o => o.Date);
         }
+
+        public override bool IsWeekend(DateTime date) =>
+            weekendProvider.IsWeekend(date);
     }
 }

--- a/Src/Nager.Date/PublicHolidays/MexicoProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/MexicoProvider.cs
@@ -1,6 +1,6 @@
-﻿using Nager.Date.Extensions;
+﻿using Nager.Date.Contract;
+using Nager.Date.Extensions;
 using Nager.Date.Model;
-using Nager.Date.Weekends;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -9,10 +9,8 @@ namespace Nager.Date.PublicHolidays
 {
     public class MexicoProvider : CatholicBaseProvider
     {
-        public MexicoProvider()
+        public MexicoProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
         {
-            //https://en.wikipedia.org/wiki/Workweek_and_weekend#Around_the_world
-            weekendProvider = new SundayOnlyProvider();
         }
 
         public override IEnumerable<PublicHoliday> Get(int year)
@@ -48,6 +46,6 @@ namespace Nager.Date.PublicHolidays
         }
 
         public override bool IsWeekend(DateTime date) =>
-            weekendProvider.IsWeekend(date);
+            _weekendProvider.IsWeekend(date);
     }
 }

--- a/Src/Nager.Date/PublicHolidays/MoldovaProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/MoldovaProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Model;
+﻿using Nager.Date.Contract;
+using Nager.Date.Model;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -7,6 +8,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class MoldovaProvider : OrthodoxBaseProvider
     {
+        public MoldovaProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Moldova
@@ -27,7 +32,7 @@ namespace Nager.Date.PublicHolidays
             items.Add(new PublicHoliday(lastMondayInMay, "Memorial Day", "Memorial Day", countryCode));
             items.Add(new PublicHoliday(year, 5, 1, "Labour Day (Moldova)", "Labour Day (Moldova)", countryCode));
             items.Add(new PublicHoliday(year, 5, 9, "Victory and Commemoration Day", "Victory and Commemoration Day", countryCode));
-            items.Add(new PublicHoliday(year, 5, 22, "Bălţi Day", "Bălţi Day", countryCode));           
+            items.Add(new PublicHoliday(year, 5, 22, "Bălţi Day", "Bălţi Day", countryCode));
             items.Add(new PublicHoliday(year, 8, 27, "Independence Day (Moldova)", "Independence Day (Moldova)", countryCode));
             items.Add(new PublicHoliday(year, 8, 31, "Limba Noastra (National Language Day (Moldova))", "Limba Noastra (National Language Day (Moldova))", countryCode));
             items.Add(new PublicHoliday(year, 9, 3, "Day of the Moldovan National Army", "Day of the Moldovan National Army", countryCode));

--- a/Src/Nager.Date/PublicHolidays/MonacoProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/MonacoProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Extensions;
+﻿using Nager.Date.Contract;
+using Nager.Date.Extensions;
 using Nager.Date.Model;
 using System;
 using System.Collections.Generic;
@@ -8,6 +9,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class MonacoProvider : CatholicBaseProvider
     {
+        public MonacoProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Monaco
@@ -17,7 +22,7 @@ namespace Nager.Date.PublicHolidays
             var easterSunday = base.EasterSunday(year);
 
             var items = new List<PublicHoliday>();
-            
+
             items.Add(new PublicHoliday(year, 1, 27, "La Sainte Dévote", "Saint Devota's Day", countryCode));
             items.Add(new PublicHoliday(easterSunday.AddDays(1), "Easter Monday", "Easter Monday", countryCode));
             items.Add(new PublicHoliday(year, 5, 1, "Le 1er mai", "May Day", countryCode));

--- a/Src/Nager.Date/PublicHolidays/MoroccoProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/MoroccoProvider.cs
@@ -1,6 +1,5 @@
 ﻿using Nager.Date.Contract;
 using Nager.Date.Model;
-using Nager.Date.Weekends;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -9,8 +8,12 @@ namespace Nager.Date.PublicHolidays
 {
     public class MoroccoProvider : IOffDaysProvider
     {
-        //https://en.wikipedia.org/wiki/Workweek_and_weekend#Around_the_world
-        private readonly IWeekendProvider weekendProvider = new UniversalWeekendProvider();
+        private readonly IWeekendProvider _weekendProvider;
+
+        public MoroccoProvider(IWeekendProvider weekendProvider)
+        {
+            _weekendProvider = weekendProvider ?? throw new ArgumentNullException(nameof(weekendProvider));
+        }
 
         public IEnumerable<PublicHoliday> Get(int year)
         {
@@ -39,6 +42,6 @@ namespace Nager.Date.PublicHolidays
         }
 
         public bool IsWeekend(DateTime date) =>
-            weekendProvider.IsWeekend(date);
+            _weekendProvider.IsWeekend(date);
     }
 }

--- a/Src/Nager.Date/PublicHolidays/MoroccoProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/MoroccoProvider.cs
@@ -1,12 +1,17 @@
 ﻿using Nager.Date.Contract;
 using Nager.Date.Model;
+using Nager.Date.Weekends;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
 namespace Nager.Date.PublicHolidays
 {
-    public class MoroccoProvider : IPublicHolidayProvider
+    public class MoroccoProvider : IOffDaysProvider
     {
+        //https://en.wikipedia.org/wiki/Workweek_and_weekend#Around_the_world
+        private readonly IWeekendProvider weekendProvider = new UniversalWeekendProvider();
+
         public IEnumerable<PublicHoliday> Get(int year)
         {
             //Morocco
@@ -32,5 +37,8 @@ namespace Nager.Date.PublicHolidays
 
             return items.OrderBy(o => o.Date);
         }
+
+        public bool IsWeekend(DateTime date) =>
+            weekendProvider.IsWeekend(date);
     }
 }

--- a/Src/Nager.Date/PublicHolidays/MozambiqueProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/MozambiqueProvider.cs
@@ -1,12 +1,17 @@
 ﻿using Nager.Date.Contract;
 using Nager.Date.Model;
+using Nager.Date.Weekends;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
 namespace Nager.Date.PublicHolidays
 {
-    public class MozambiqueProvider : IPublicHolidayProvider, ICountyProvider
+    public class MozambiqueProvider : IOffDaysProvider, ICountyProvider
     {
+        //https://en.wikipedia.org/wiki/Workweek_and_weekend#Around_the_world
+        private readonly IWeekendProvider weekendProvider = new UniversalWeekendProvider();
+
         public IEnumerable<PublicHoliday> Get(int year)
         {
             //Mozambique
@@ -47,5 +52,8 @@ namespace Nager.Date.PublicHolidays
                 { "MZ-ZA", "Zambezia" }
             };
         }
+
+        public bool IsWeekend(DateTime date) =>
+            weekendProvider.IsWeekend(date);
     }
 }

--- a/Src/Nager.Date/PublicHolidays/MozambiqueProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/MozambiqueProvider.cs
@@ -1,6 +1,5 @@
 ﻿using Nager.Date.Contract;
 using Nager.Date.Model;
-using Nager.Date.Weekends;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -9,9 +8,12 @@ namespace Nager.Date.PublicHolidays
 {
     public class MozambiqueProvider : IOffDaysProvider, ICountyProvider
     {
-        //https://en.wikipedia.org/wiki/Workweek_and_weekend#Around_the_world
-        private readonly IWeekendProvider weekendProvider = new UniversalWeekendProvider();
+        private readonly IWeekendProvider _weekendProvider;
 
+        public MozambiqueProvider(IWeekendProvider weekendProvider)
+        {
+            _weekendProvider = weekendProvider ?? throw new ArgumentNullException(nameof(weekendProvider));
+        }
         public IEnumerable<PublicHoliday> Get(int year)
         {
             //Mozambique
@@ -54,6 +56,6 @@ namespace Nager.Date.PublicHolidays
         }
 
         public bool IsWeekend(DateTime date) =>
-            weekendProvider.IsWeekend(date);
+            _weekendProvider.IsWeekend(date);
     }
 }

--- a/Src/Nager.Date/PublicHolidays/NamibiaProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/NamibiaProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Model;
+﻿using Nager.Date.Contract;
+using Nager.Date.Model;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -6,6 +7,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class NamibiaProvider : CatholicBaseProvider
     {
+        public NamibiaProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Namibia

--- a/Src/Nager.Date/PublicHolidays/NetherlandsProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/NetherlandsProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Model;
+﻿using Nager.Date.Contract;
+using Nager.Date.Model;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -7,6 +8,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class NetherlandsProvider : CatholicBaseProvider
     {
+        public NetherlandsProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Netherlands

--- a/Src/Nager.Date/PublicHolidays/NewZealandProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/NewZealandProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Extensions;
+﻿using Nager.Date.Contract;
+using Nager.Date.Extensions;
 using Nager.Date.Model;
 using System;
 using System.Collections.Generic;
@@ -8,6 +9,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class NewZealandProvider : CatholicBaseProvider
     {
+        public NewZealandProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //New Zealand

--- a/Src/Nager.Date/PublicHolidays/NicaraguaProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/NicaraguaProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Model;
+﻿using Nager.Date.Contract;
+using Nager.Date.Model;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -7,6 +8,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class NicaraguaProvider : CatholicBaseProvider
     {
+        public NicaraguaProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Nicaragua

--- a/Src/Nager.Date/PublicHolidays/NorwayProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/NorwayProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Model;
+﻿using Nager.Date.Contract;
+using Nager.Date.Model;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -6,6 +7,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class NorwayProvider : CatholicBaseProvider
     {
+        public NorwayProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Norway

--- a/Src/Nager.Date/PublicHolidays/OrthodoxBaseProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/OrthodoxBaseProvider.cs
@@ -1,12 +1,15 @@
 ﻿using Nager.Date.Contract;
 using Nager.Date.Model;
+using Nager.Date.Weekends;
 using System;
 using System.Collections.Generic;
 
 namespace Nager.Date.PublicHolidays
 {
-    public abstract class OrthodoxBaseProvider : IPublicHolidayProvider
+    public abstract class OrthodoxBaseProvider : IOffDaysProvider
     {
+        protected IWeekendProvider weekendProvider = new UniversalWeekendProvider();
+
         public abstract IEnumerable<PublicHoliday> Get(int year);
 
         /// <summary>
@@ -30,5 +33,8 @@ namespace Nager.Date.PublicHolidays
 
             return new DateTime(year, month, day);
         }
+
+        public bool IsWeekend(DateTime date) =>
+            weekendProvider.IsWeekend(date);
     }
 }

--- a/Src/Nager.Date/PublicHolidays/OrthodoxBaseProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/OrthodoxBaseProvider.cs
@@ -1,6 +1,5 @@
 ﻿using Nager.Date.Contract;
 using Nager.Date.Model;
-using Nager.Date.Weekends;
 using System;
 using System.Collections.Generic;
 
@@ -8,7 +7,12 @@ namespace Nager.Date.PublicHolidays
 {
     public abstract class OrthodoxBaseProvider : IOffDaysProvider
     {
-        protected IWeekendProvider weekendProvider = new UniversalWeekendProvider();
+        protected IWeekendProvider _weekendProvider;
+
+        protected OrthodoxBaseProvider(IWeekendProvider weekendProvider)
+        {
+            _weekendProvider = weekendProvider ?? throw new ArgumentNullException(nameof(weekendProvider));
+        }
 
         public abstract IEnumerable<PublicHoliday> Get(int year);
 
@@ -35,6 +39,6 @@ namespace Nager.Date.PublicHolidays
         }
 
         public bool IsWeekend(DateTime date) =>
-            weekendProvider.IsWeekend(date);
+            _weekendProvider.IsWeekend(date);
     }
 }

--- a/Src/Nager.Date/PublicHolidays/PanamaProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/PanamaProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Model;
+﻿using Nager.Date.Contract;
+using Nager.Date.Model;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -6,6 +7,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class PanamaProvider : CatholicBaseProvider
     {
+        public PanamaProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Panama

--- a/Src/Nager.Date/PublicHolidays/ParaguayProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/ParaguayProvider.cs
@@ -7,6 +7,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class ParaguayProvider : CatholicBaseProvider
     {
+        public ParaguayProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Paraguay
@@ -16,7 +20,7 @@ namespace Nager.Date.PublicHolidays
             var easterSunday = base.EasterSunday(year);
 
             var items = new List<PublicHoliday>();
-            
+
             items.Add(new PublicHoliday(year, 1, 1, "New Year's Day", "New Year's Day", countryCode));
             items.Add(new PublicHoliday(year, 3, 1, "Dia de los héroes", "Heroes' day", countryCode));
             items.Add(new PublicHoliday(easterSunday.AddDays(-3), "Jueves Santo", "Maundy Thursday", countryCode));
@@ -29,7 +33,7 @@ namespace Nager.Date.PublicHolidays
             items.Add(new PublicHoliday(year, 9, 29, "Victoria de Boquerón", "Boqueron Battle Victory Day", countryCode));
             items.Add(new PublicHoliday(year, 12, 8, "Virgen de Caacupé", "Virgin of Caacupe", countryCode));
             items.Add(new PublicHoliday(year, 12, 25, "Día de Navidad", "Christmas Day", countryCode));
-            
+
             return items.OrderBy(o => o.Date);
         }
     }

--- a/Src/Nager.Date/PublicHolidays/PeruProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/PeruProvider.cs
@@ -1,3 +1,4 @@
+using Nager.Date.Contract;
 using Nager.Date.Model;
 using System.Collections.Generic;
 using System.Linq;
@@ -6,6 +7,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class PeruProvider : CatholicBaseProvider
     {
+        public PeruProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Peru
@@ -15,7 +20,7 @@ namespace Nager.Date.PublicHolidays
             var easterSunday = base.EasterSunday(year);
 
             var items = new List<PublicHoliday>();
-            
+
             items.Add(new PublicHoliday(year, 1, 1, "Año Nuevo", "New Year's Day", countryCode));
             items.Add(new PublicHoliday(easterSunday.AddDays(-3), "Jueves Santo", "Holy Thursday", countryCode));
             items.Add(new PublicHoliday(easterSunday.AddDays(-2), "Viernes Santo", "Good Friday", countryCode));
@@ -29,7 +34,7 @@ namespace Nager.Date.PublicHolidays
             items.Add(new PublicHoliday(year, 11, 1, "Día de Todos los Santos", "All Saints Day", countryCode));
             items.Add(new PublicHoliday(year, 12, 8, "Inmaculada Concepción", "Immaculate Conception", countryCode));
             items.Add(new PublicHoliday(year, 12, 25, "Navidad", "Christmas Day", countryCode));
-            
+
             return items.OrderBy(o => o.Date);
         }
     }

--- a/Src/Nager.Date/PublicHolidays/PolandProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/PolandProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Model;
+﻿using Nager.Date.Contract;
+using Nager.Date.Model;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -6,6 +7,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class PolandProvider : CatholicBaseProvider
     {
+        public PolandProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Poland

--- a/Src/Nager.Date/PublicHolidays/PortugalProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/PortugalProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Model;
+﻿using Nager.Date.Contract;
+using Nager.Date.Model;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -6,6 +7,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class PortugalProvider : CatholicBaseProvider
     {
+        public PortugalProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Portugal

--- a/Src/Nager.Date/PublicHolidays/PuertoRicoProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/PuertoRicoProvider.cs
@@ -1,14 +1,19 @@
 ﻿
+using Nager.Date.Contract;
+using Nager.Date.Extensions;
+using Nager.Date.Model;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Nager.Date.Extensions;
-using Nager.Date.Model;
 
 namespace Nager.Date.PublicHolidays
 {
     public class PuertoRicoProvider : CatholicBaseProvider
     {
+        public PuertoRicoProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             // Puerto Rico
@@ -55,7 +60,7 @@ namespace Nager.Date.PublicHolidays
             items.Add(new PublicHoliday(independenceDay, "Día de la Independencia de los Estados Unidos", "Independence Day", countryCode));
 
             #endregion
-            
+
             items.Add(new PublicHoliday(thirdMondayInJuly, "Natalicio de Don Luis Muñoz Rivera", "Birthday of Don Luis Muñoz Rivera", countryCode));
             items.Add(new PublicHoliday(year, 7, 25, "Constitución de Puerto Rico", "Puerto Rico Constitution Day", countryCode));
             items.Add(new PublicHoliday(year, 7, 27, "Natalicio de Dr. José Celso Barbosa", "Birthday of Dr. José Celso Barbosa", countryCode));
@@ -68,12 +73,12 @@ namespace Nager.Date.PublicHolidays
             items.Add(new PublicHoliday(veteransDay, "Día del Veterano Día del Armisticio", "Veterans Day", countryCode));
 
             #endregion
-            
+
             items.Add(new PublicHoliday(year, 11, 19, "Día del Descubrimiento de Puerto Rico", "Discovery of Puerto Rico", countryCode));
             items.Add(new PublicHoliday(fourthThursdayInNovember, "Día de Acción de Gracias", "Thanksgiving Day", countryCode));
             items.Add(new PublicHoliday(year, 12, 24, "Noche Buena", "Christmas Eve", countryCode));
             items.Add(new PublicHoliday(year, 12, 25, "Navidad", "Christmas Day", countryCode));
-            
+
             return items.OrderBy(o => o.Date);
         }
     }

--- a/Src/Nager.Date/PublicHolidays/RomaniaProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/RomaniaProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Model;
+﻿using Nager.Date.Contract;
+using Nager.Date.Model;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -6,6 +7,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class RomaniaProvider : OrthodoxBaseProvider
     {
+        public RomaniaProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Romania

--- a/Src/Nager.Date/PublicHolidays/RussiaProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/RussiaProvider.cs
@@ -1,12 +1,17 @@
 ﻿using Nager.Date.Contract;
 using Nager.Date.Model;
+using Nager.Date.Weekends;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
 namespace Nager.Date.PublicHolidays
 {
-    public class RussiaProvider : IPublicHolidayProvider
+    public class RussiaProvider : IOffDaysProvider
     {
+        //https://en.wikipedia.org/wiki/Workweek_and_weekend#Around_the_world
+        private readonly IWeekendProvider weekendProvider = new UniversalWeekendProvider();
+
         public IEnumerable<PublicHoliday> Get(int year)
         {
             //Russia
@@ -31,5 +36,8 @@ namespace Nager.Date.PublicHolidays
 
             return items.OrderBy(o => o.Date);
         }
+
+        public bool IsWeekend(DateTime date) =>
+            weekendProvider.IsWeekend(date);
     }
 }

--- a/Src/Nager.Date/PublicHolidays/RussiaProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/RussiaProvider.cs
@@ -1,6 +1,5 @@
 ﻿using Nager.Date.Contract;
 using Nager.Date.Model;
-using Nager.Date.Weekends;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -9,8 +8,12 @@ namespace Nager.Date.PublicHolidays
 {
     public class RussiaProvider : IOffDaysProvider
     {
-        //https://en.wikipedia.org/wiki/Workweek_and_weekend#Around_the_world
-        private readonly IWeekendProvider weekendProvider = new UniversalWeekendProvider();
+        private readonly IWeekendProvider _weekendProvider;
+
+        public RussiaProvider(IWeekendProvider weekendProvider)
+        {
+            _weekendProvider = weekendProvider ?? throw new ArgumentNullException(nameof(weekendProvider));
+        }
 
         public IEnumerable<PublicHoliday> Get(int year)
         {
@@ -38,6 +41,6 @@ namespace Nager.Date.PublicHolidays
         }
 
         public bool IsWeekend(DateTime date) =>
-            weekendProvider.IsWeekend(date);
+            _weekendProvider.IsWeekend(date);
     }
 }

--- a/Src/Nager.Date/PublicHolidays/SanMarinoProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/SanMarinoProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Model;
+﻿using Nager.Date.Contract;
+using Nager.Date.Model;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -6,6 +7,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class SanMarinoProvider : CatholicBaseProvider
     {
+        public SanMarinoProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //San Marino 
@@ -23,7 +28,7 @@ namespace Nager.Date.PublicHolidays
             items.Add(new PublicHoliday(easterSunday.AddDays(1), "Easter Monday", "Easter Monday", countryCode));
             items.Add(new PublicHoliday(year, 3, 25, "Anniversary of the Arengo", "Anniversary of the Arengo", countryCode));
             items.Add(new PublicHoliday(year, 5, 1, "Labour Day", "Labour Day", countryCode));
-            items.Add(new PublicHoliday(easterSunday.AddDays(60), "Corpus Christi", "Corpus Christi", countryCode)); 
+            items.Add(new PublicHoliday(easterSunday.AddDays(60), "Corpus Christi", "Corpus Christi", countryCode));
             items.Add(new PublicHoliday(year, 7, 28, "Liberation from Fascism", "Liberation from Fascism", countryCode));
             items.Add(new PublicHoliday(year, 8, 15, "Ferragosto (Assumption)", "Ferragosto (Assumption)", countryCode));
             items.Add(new PublicHoliday(year, 9, 3, "The Feast of San Marino and the Republic", "The Feast of San Marino and the Republic", countryCode));

--- a/Src/Nager.Date/PublicHolidays/SerbiaProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/SerbiaProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Model;
+﻿using Nager.Date.Contract;
+using Nager.Date.Model;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -6,6 +7,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class SerbiaProvider : OrthodoxBaseProvider
     {
+        public SerbiaProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Serbia

--- a/Src/Nager.Date/PublicHolidays/SlovakiaProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/SlovakiaProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Model;
+﻿using Nager.Date.Contract;
+using Nager.Date.Model;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -6,6 +7,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class SlovakiaProvider : CatholicBaseProvider
     {
+        public SlovakiaProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Slovakia

--- a/Src/Nager.Date/PublicHolidays/SloveniaProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/SloveniaProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Model;
+﻿using Nager.Date.Contract;
+using Nager.Date.Model;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -6,6 +7,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class SloveniaProvider : CatholicBaseProvider
     {
+        public SloveniaProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Slovenia

--- a/Src/Nager.Date/PublicHolidays/SouthAfricaProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/SouthAfricaProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Model;
+﻿using Nager.Date.Contract;
+using Nager.Date.Model;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -6,6 +7,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class SouthAfricaProvider : CatholicBaseProvider
     {
+        public SouthAfricaProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //South Africa

--- a/Src/Nager.Date/PublicHolidays/SpainProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/SpainProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Model;
+﻿using Nager.Date.Contract;
+using Nager.Date.Model;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -6,6 +7,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class SpainProvider : CatholicBaseProvider
     {
+        public SpainProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Spain

--- a/Src/Nager.Date/PublicHolidays/SurinameProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/SurinameProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Model;
+﻿using Nager.Date.Contract;
+using Nager.Date.Model;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -8,6 +9,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class SurinameProvider : CatholicBaseProvider
     {
+        public SurinameProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Suriname

--- a/Src/Nager.Date/PublicHolidays/SvalbardAndJanMayenProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/SvalbardAndJanMayenProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Model;
+﻿using Nager.Date.Contract;
+using Nager.Date.Model;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -6,6 +7,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class SvalbardAndJanMayenProvider : CatholicBaseProvider
     {
+        public SvalbardAndJanMayenProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Svalbard and Jan Mayen 

--- a/Src/Nager.Date/PublicHolidays/SwedenProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/SwedenProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Model;
+﻿using Nager.Date.Contract;
+using Nager.Date.Model;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -7,6 +8,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class SwedenProvider : CatholicBaseProvider
     {
+        public SwedenProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Sweden

--- a/Src/Nager.Date/PublicHolidays/SwitzerlandProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/SwitzerlandProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Model;
+﻿using Nager.Date.Contract;
+using Nager.Date.Model;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -7,6 +8,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class SwitzerlandProvider : CatholicBaseProvider
     {
+        public SwitzerlandProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Switzerland

--- a/Src/Nager.Date/PublicHolidays/TunisiaProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/TunisiaProvider.cs
@@ -1,12 +1,17 @@
 ﻿using Nager.Date.Contract;
 using Nager.Date.Model;
+using Nager.Date.Weekends;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
 namespace Nager.Date.PublicHolidays
 {
-    public class TunisiaProvider : IPublicHolidayProvider
+    public class TunisiaProvider : IOffDaysProvider
     {
+        //https://en.wikipedia.org/wiki/Workweek_and_weekend#Around_the_world
+        private readonly IWeekendProvider weekendProvider = new UniversalWeekendProvider();
+
         public IEnumerable<PublicHoliday> Get(int year)
         {
             //Tunisia
@@ -33,5 +38,8 @@ namespace Nager.Date.PublicHolidays
 
             return items.OrderBy(o => o.Date);
         }
+
+        public bool IsWeekend(DateTime date) =>
+            weekendProvider.IsWeekend(date);
     }
 }

--- a/Src/Nager.Date/PublicHolidays/TunisiaProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/TunisiaProvider.cs
@@ -1,6 +1,5 @@
 ﻿using Nager.Date.Contract;
 using Nager.Date.Model;
-using Nager.Date.Weekends;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -9,8 +8,12 @@ namespace Nager.Date.PublicHolidays
 {
     public class TunisiaProvider : IOffDaysProvider
     {
-        //https://en.wikipedia.org/wiki/Workweek_and_weekend#Around_the_world
-        private readonly IWeekendProvider weekendProvider = new UniversalWeekendProvider();
+        private readonly IWeekendProvider _weekendProvider;
+
+        public TunisiaProvider(IWeekendProvider weekendProvider)
+        {
+            _weekendProvider = weekendProvider ?? throw new ArgumentNullException(nameof(weekendProvider));
+        }
 
         public IEnumerable<PublicHoliday> Get(int year)
         {
@@ -40,6 +43,6 @@ namespace Nager.Date.PublicHolidays
         }
 
         public bool IsWeekend(DateTime date) =>
-            weekendProvider.IsWeekend(date);
+            _weekendProvider.IsWeekend(date);
     }
 }

--- a/Src/Nager.Date/PublicHolidays/TurkeyProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/TurkeyProvider.cs
@@ -1,6 +1,5 @@
 ﻿using Nager.Date.Contract;
 using Nager.Date.Model;
-using Nager.Date.Weekends;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -9,8 +8,12 @@ namespace Nager.Date.PublicHolidays
 {
     public class TurkeyProvider : IOffDaysProvider
     {
-        //https://en.wikipedia.org/wiki/Workweek_and_weekend#Around_the_world
-        private readonly IWeekendProvider weekendProvider = new UniversalWeekendProvider();
+        private readonly IWeekendProvider _weekendProvider;
+
+        public TurkeyProvider(IWeekendProvider weekendProvider)
+        {
+            _weekendProvider = weekendProvider ?? throw new ArgumentNullException(nameof(weekendProvider));
+        }
 
         public IEnumerable<PublicHoliday> Get(int year)
         {
@@ -33,6 +36,6 @@ namespace Nager.Date.PublicHolidays
         }
 
         public bool IsWeekend(DateTime date) =>
-            weekendProvider.IsWeekend(date);
+            _weekendProvider.IsWeekend(date);
     }
 }

--- a/Src/Nager.Date/PublicHolidays/TurkeyProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/TurkeyProvider.cs
@@ -1,12 +1,17 @@
 ﻿using Nager.Date.Contract;
 using Nager.Date.Model;
+using Nager.Date.Weekends;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
 namespace Nager.Date.PublicHolidays
 {
-    public class TurkeyProvider : IPublicHolidayProvider
+    public class TurkeyProvider : IOffDaysProvider
     {
+        //https://en.wikipedia.org/wiki/Workweek_and_weekend#Around_the_world
+        private readonly IWeekendProvider weekendProvider = new UniversalWeekendProvider();
+
         public IEnumerable<PublicHoliday> Get(int year)
         {
             //Turkey
@@ -26,5 +31,8 @@ namespace Nager.Date.PublicHolidays
 
             return items.OrderBy(o => o.Date);
         }
+
+        public bool IsWeekend(DateTime date) =>
+            weekendProvider.IsWeekend(date);
     }
 }

--- a/Src/Nager.Date/PublicHolidays/UkraineProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/UkraineProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Model;
+﻿using Nager.Date.Contract;
+using Nager.Date.Model;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -6,6 +7,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class UkraineProvider : OrthodoxBaseProvider
     {
+        public UkraineProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Ukraine

--- a/Src/Nager.Date/PublicHolidays/UnitedKingdomProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/UnitedKingdomProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Extensions;
+﻿using Nager.Date.Contract;
+using Nager.Date.Extensions;
 using Nager.Date.Model;
 using System;
 using System.Collections.Generic;
@@ -8,6 +9,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class UnitedKingdomProvider : CatholicBaseProvider
     {
+        public UnitedKingdomProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //United Kingdom

--- a/Src/Nager.Date/PublicHolidays/UnitedStatesProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/UnitedStatesProvider.cs
@@ -1,7 +1,6 @@
 ﻿using Nager.Date.Contract;
 using Nager.Date.Extensions;
 using Nager.Date.Model;
-using Nager.Date.Weekends;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -10,8 +9,12 @@ namespace Nager.Date.PublicHolidays
 {
     public class UnitedStatesProvider : IOffDaysProvider
     {
-        //https://en.wikipedia.org/wiki/Workweek_and_weekend#Around_the_world
-        private readonly IWeekendProvider weekendProvider = new UniversalWeekendProvider();
+        private readonly IWeekendProvider _weekendProvider;
+
+        public UnitedStatesProvider(IWeekendProvider weekendProvider)
+        {
+            _weekendProvider = weekendProvider ?? throw new ArgumentNullException(nameof(weekendProvider));
+        }
 
         public IEnumerable<PublicHoliday> Get(int year)
         {
@@ -86,6 +89,6 @@ namespace Nager.Date.PublicHolidays
         }
 
         public bool IsWeekend(DateTime date) =>
-            weekendProvider.IsWeekend(date);
+            _weekendProvider.IsWeekend(date);
     }
 }

--- a/Src/Nager.Date/PublicHolidays/UnitedStatesProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/UnitedStatesProvider.cs
@@ -1,14 +1,18 @@
 ﻿using Nager.Date.Contract;
 using Nager.Date.Extensions;
 using Nager.Date.Model;
+using Nager.Date.Weekends;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 
 namespace Nager.Date.PublicHolidays
 {
-    public class UnitedStatesProvider : IPublicHolidayProvider
+    public class UnitedStatesProvider : IOffDaysProvider
     {
+        //https://en.wikipedia.org/wiki/Workweek_and_weekend#Around_the_world
+        private readonly IWeekendProvider weekendProvider = new UniversalWeekendProvider();
+
         public IEnumerable<PublicHoliday> Get(int year)
         {
             //United States of America
@@ -31,7 +35,7 @@ namespace Nager.Date.PublicHolidays
             items.Add(new PublicHoliday(newYearsDay, "New Year's Day", "New Year's Day", countryCode));
 
             #endregion
-            
+
             items.Add(new PublicHoliday(thirdMondayInJannuar, "Martin Luther King, Jr. Day", "Martin Luther King, Jr. Day", countryCode));
             items.Add(new PublicHoliday(thirdMondayInFebruary, "Washington's Birthday", "Presidents' Day", countryCode));
             items.Add(new PublicHoliday(lastMondayInMay, "Memorial Day", "Memorial Day", countryCode));
@@ -42,7 +46,7 @@ namespace Nager.Date.PublicHolidays
             items.Add(new PublicHoliday(independenceDay, "Independence Day", "Independence Day", countryCode));
 
             #endregion
-            
+
             items.Add(new PublicHoliday(firstMondayInSeptember, "Labor Day", "Labour Day", countryCode));
             items.Add(new PublicHoliday(secondMondayInOctober, "Columbus Day", "Columbus Day", countryCode, null, new string[] { "US-AL", "US-AZ", "US-CO", "US-CT", "US-DC", "US-GA", "US-ID", "US-IL", "US-IN", "US-IA", "US-KS", "US-KY", "US-LA", "US-ME", "US-MD", "US-MA", "US-MS", "US-MO", "US-MT", "US-NE", "US-NH", "US-NJ", "US-NM", "US-NY", "US-NC", "US-OH", "US-OK", "US-PA", "US-RI", "US-SC", "US-TN", "US-UT", "US-VA", "US-WV" }));
 
@@ -54,7 +58,7 @@ namespace Nager.Date.PublicHolidays
             #endregion
 
             items.Add(new PublicHoliday(fourthThursdayInNovember, "Thanksgiving Day", "Thanksgiving Day", countryCode, 1863));
-            
+
             #region Christmas Day with fallback
 
             var christmasDay = new DateTime(year, 12, 25).Shift(saturday => saturday.AddDays(-1), sunday => sunday.AddDays(1));
@@ -80,5 +84,8 @@ namespace Nager.Date.PublicHolidays
 
             return items.OrderBy(o => o.Date);
         }
+
+        public bool IsWeekend(DateTime date) =>
+            weekendProvider.IsWeekend(date);
     }
 }

--- a/Src/Nager.Date/PublicHolidays/UruguayProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/UruguayProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Model;
+﻿using Nager.Date.Contract;
+using Nager.Date.Model;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -6,6 +7,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class UruguayProvider : CatholicBaseProvider
     {
+        public UruguayProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Uruguay

--- a/Src/Nager.Date/PublicHolidays/VaticanCityProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/VaticanCityProvider.cs
@@ -1,14 +1,16 @@
-﻿using Nager.Date.Model;
-using System;
+﻿using Nager.Date.Contract;
+using Nager.Date.Model;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace Nager.Date.PublicHolidays 
+namespace Nager.Date.PublicHolidays
 {
     public class VaticanCityProvider : CatholicBaseProvider
     {
+        public VaticanCityProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Vatican City

--- a/Src/Nager.Date/PublicHolidays/VenezuelaProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/VenezuelaProvider.cs
@@ -1,4 +1,5 @@
-﻿using Nager.Date.Model;
+﻿using Nager.Date.Contract;
+using Nager.Date.Model;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -7,6 +8,10 @@ namespace Nager.Date.PublicHolidays
 {
     public class VenezuelaProvider : CatholicBaseProvider
     {
+        public VenezuelaProvider(IWeekendProvider weekendProvider) : base(weekendProvider)
+        {
+        }
+
         public override IEnumerable<PublicHoliday> Get(int year)
         {
             //Venezuela

--- a/Src/Nager.Date/Weekends/SemiUniversalWeekendProvider.cs
+++ b/Src/Nager.Date/Weekends/SemiUniversalWeekendProvider.cs
@@ -1,0 +1,11 @@
+﻿using Nager.Date.Contract;
+using System;
+
+namespace Nager.Date.Weekends
+{
+    public class SemiUniversalWeekendProvider : IWeekendProvider
+    {
+        public bool IsWeekend(DateTime date) =>
+            date.DayOfWeek == DayOfWeek.Friday || date.DayOfWeek == DayOfWeek.Saturday;
+    }
+}

--- a/Src/Nager.Date/Weekends/SundayOnlyProvider.cs
+++ b/Src/Nager.Date/Weekends/SundayOnlyProvider.cs
@@ -1,0 +1,11 @@
+﻿using Nager.Date.Contract;
+using System;
+
+namespace Nager.Date.Weekends
+{
+    public class SundayOnlyProvider : IWeekendProvider
+    {
+        public bool IsWeekend(DateTime date) =>
+            date.DayOfWeek == DayOfWeek.Sunday;
+    }
+}

--- a/Src/Nager.Date/Weekends/UniversalWeekendProvider.cs
+++ b/Src/Nager.Date/Weekends/UniversalWeekendProvider.cs
@@ -1,0 +1,11 @@
+﻿using Nager.Date.Contract;
+using System;
+
+namespace Nager.Date.Weekends
+{
+    public class UniversalWeekendProvider : IWeekendProvider
+    {
+        public bool IsWeekend(DateTime date) =>
+            date.DayOfWeek == DayOfWeek.Saturday || date.DayOfWeek == DayOfWeek.Sunday;
+    }
+}


### PR DESCRIPTION
Here is a suggestion for the IsWeekend extension implementation (following #109).

I took several decisions that you, obviously, might question/reject:
- Added a IWeekendProvider interface (plus an IOffDaysProvider interface to aggregate both IWeekend and IPublidHoliday interfaces)
- Provided a default weekend provider whenever relevant (e.g. catholic and orthodox providers base classes)
- Overrode the default provider whenever needed
- Added a Shift method where you can define the source day (as the other Shift method rely on universal weekend, which is not right for each culture). Maybe those generic methods could be enhanced to be more culture aware, or maybe marked as Obsolete (that's probably what I would have done on a project of mine, but you're in charge here 😄).

This seemed like the lightest way to do it (that didn't require larger changes), but of course you might want to suggest another approach.
I mostly relied on [Wikipedia's workweek and weekend page](https://en.wikipedia.org/wiki/Workweek_and_weekend) to find the relevant information, but not all coutries are available. In this case, those countries fall back to the default weekend provider (which mostly replicates the previous behavior, i.e. universal weekend everywhere).

I also added some tests for the weekend providers and completed the unit tests for the already existing countries tests. I went this way to keep the tests inside the countries tests classes and keep things simple, but that leads to some duplication in the tests. Please let me know if you'd rather to arrange things differently.

Let me know what you think, feel free to request some changes.

Thanks! 😄 