### PR TITLE
Added Kosovo country

### DIFF
--- a/Src/Nager.Date.UnitTest/Country/KosovoTest.cs
+++ b/Src/Nager.Date.UnitTest/Country/KosovoTest.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Linq;
+
+namespace Nager.Date.UnitTest.Country
+{
+    [TestClass]
+    public class KosovoTest
+    {
+        [TestMethod]
+        public void TestKosova()
+
+        {
+            var publicHolidays = DateSystem.GetPublicHoliday(2019, CountryCode.XK).ToArray();
+
+            //New Year's Day
+            Assert.AreEqual(new DateTime(2019, 1, 1), publicHolidays[0].Date);
+            //Orthodox Christmas
+            Assert.AreEqual(new DateTime(2019, 1, 7), publicHolidays[1].Date);
+            //Independence Day
+            Assert.AreEqual(new DateTime(2019, 2, 17), publicHolidays[2].Date);
+            //Constitution Day
+            Assert.AreEqual(new DateTime(2019, 4, 9), publicHolidays[3].Date);
+            //Catholic Easter
+            Assert.AreEqual(new DateTime(2019, 4, 21), publicHolidays[4].Date);
+            //Orthodox Easter
+            Assert.AreEqual(new DateTime(2019, 4, 28), publicHolidays[5].Date);
+            //International Workers' Day
+            Assert.AreEqual(new DateTime(2019, 5, 1), publicHolidays[6].Date);
+            //Europe Day
+            Assert.AreEqual(new DateTime(2019, 5, 9), publicHolidays[7].Date);
+
+            //Eid ul-Fitr is not implemented
+            //Eid ul-Adha is not implemented
+
+            //Catholic Christmas
+            Assert.AreEqual(new DateTime(2019, 12, 25), publicHolidays[8].Date);
+        }
+    }
+}

--- a/Src/Nager.Date.UnitTest/Nager.Date.UnitTest.csproj
+++ b/Src/Nager.Date.UnitTest/Nager.Date.UnitTest.csproj
@@ -56,6 +56,7 @@
     <Compile Include="Common\LogicTest.cs" />
     <Compile Include="Common\LongWeekendTest.cs" />
     <Compile Include="Country\HungaryTest.cs" />
+    <Compile Include="Country\KosovoTest.cs" />
     <Compile Include="Country\MexicoTest.cs" />
     <Compile Include="DateTimeExtension\DateTimeExtension_Shift.cs" />
     <Compile Include="MockProvider.cs" />

--- a/Src/Nager.Date/CountryCode.cs
+++ b/Src/Nager.Date/CountryCode.cs
@@ -982,6 +982,10 @@
         /// </summary>
         WS,
         /// <summary>
+        /// Kosovo
+        /// </summary>
+        XK,
+        /// <summary>
         /// Yemen
         /// </summary>
         YE,

--- a/Src/Nager.Date/DateSystem.cs
+++ b/Src/Nager.Date/DateSystem.cs
@@ -20,6 +20,7 @@ namespace Nager.Date
         private static readonly Dictionary<CountryCode, IPublicHolidayProvider> _publicHolidaysProviders =
             new Dictionary<CountryCode, IPublicHolidayProvider>
             {
+                { CountryCode.AL, new AlbaniaProvider(_orthodoxProvider) },
                 { CountryCode.AD, new AndorraProvider() },
                 { CountryCode.AR, new ArgentinaProvider(_catholicProvider) },
                 { CountryCode.AT, new AustriaProvider(_catholicProvider) },
@@ -118,6 +119,7 @@ namespace Nager.Date
                 { CountryCode.VA, new VaticanCityProvider(_catholicProvider) },
                 { CountryCode.VE, new VenezuelaProvider(_catholicProvider) },
                 { CountryCode.VN, new VietnamProvider() },
+                { CountryCode.XK, new KosovoProvider(_orthodoxProvider, _catholicProvider) },
                 { CountryCode.ZA, new SouthAfricaProvider(_catholicProvider) }
             };
 

--- a/Src/Nager.Date/PublicHolidays/KosovoProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/KosovoProvider.cs
@@ -1,0 +1,58 @@
+﻿using Nager.Date.Contract;
+using Nager.Date.Model;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Nager.Date.PublicHolidays
+{
+    /// <summary>
+    /// Kosovo
+    /// https://en.wikipedia.org/wiki/Public_holidays_in_Kosovo
+    /// </summary>
+    public class KosovoProvider : IPublicHolidayProvider
+    {
+        private readonly IOrthodoxProvider _orthodoxProvider;
+        private readonly ICatholicProvider _catholicProvider;
+
+        /// <summary>
+        /// KosovoProvider
+        /// </summary>
+        /// <param name="orthodoxProvider"></param>
+        /// <param name="catholicProvider"></param>
+        public KosovoProvider(IOrthodoxProvider orthodoxProvider, ICatholicProvider catholicProvider)
+        {
+            this._orthodoxProvider = orthodoxProvider;
+            this._catholicProvider = catholicProvider;
+        }
+
+        /// <summary>
+        /// Get
+        /// </summary>
+        /// <param name="year">The year</param>
+        /// <returns></returns>
+        public IEnumerable<PublicHoliday> Get(int year)
+        {
+            var countryCode = CountryCode.XK;
+            var orthodoxEasterSunday = this._orthodoxProvider.EasterSunday(year);
+            var catholicEasterSunday = this._catholicProvider.EasterSunday(year);
+
+            var items = new List<PublicHoliday>();
+            items.Add(new PublicHoliday(year, 1, 1, "Viti i Ri", "New Year's Day", countryCode));
+            items.Add(new PublicHoliday(year, 1, 7, "Krishtlindjet Ortodokse", "Orthodox Christmas", countryCode));
+            items.Add(new PublicHoliday(year, 2, 17, "Dita e Pavarësisë", "Independence Day", countryCode));
+            items.Add(new PublicHoliday(year, 4, 9, "Dita e Kushtetutës", "Constitution Day", countryCode));
+            items.Add(new PublicHoliday(catholicEasterSunday, "Pashkët Katolike", "Catholic Easter", countryCode));
+            items.Add(new PublicHoliday(orthodoxEasterSunday, "Pashkët Ortodokse", "Orthodox Easter", countryCode));
+            items.Add(new PublicHoliday(year, 5, 1, "Dita Ndërkombëtare e Punës", "International Workers' Day", countryCode));
+            items.Add(new PublicHoliday(year, 5, 9, "Dita e Evropës", "Europe Day", countryCode));
+            //Eid ul-Fitr is not implemented
+            //Eid ul-Adha is not implemented
+            items.Add(new PublicHoliday(year, 12, 25, "Krishtlindjet Katolike", "Catholic Christmas", countryCode));
+
+            return items.OrderBy(o => o.Date);
+        }
+    }
+}


### PR DESCRIPTION
This PR contains,

- Added new country called Kosovo.
- Included Orthodox as well as catholic holidays
- Added Country code for Kosovo
- Added Kosovo in _publicHolidayProviders dictionary, also added missing country AlbaniaProvider to same dictionary.
