### PR TITLE
Corrected Dutch Easter holiday names

### DIFF
--- a/Src/Nager.Date/PublicHolidays/NetherlandsProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/NetherlandsProvider.cs
@@ -46,8 +46,8 @@ namespace Nager.Date.PublicHolidays
             var items = new List<PublicHoliday>();
             items.Add(new PublicHoliday(year, 1, 1, "Nieuwjaarsdag", "New Year's Day", countryCode, 1967));
             items.Add(new PublicHoliday(easterSunday.AddDays(-2), "Goede Vrijdag", "Good Friday", countryCode, type: PublicHolidayType.Authorities | PublicHolidayType.School));
-            items.Add(new PublicHoliday(easterSunday, "Paasfeest", "Easter Sunday", countryCode));
-            items.Add(new PublicHoliday(easterSunday.AddDays(1), " Pasen", "Easter Monday", countryCode, 1642));
+            items.Add(new PublicHoliday(easterSunday, "Eerste Paasdag", "Easter Sunday", countryCode));
+            items.Add(new PublicHoliday(easterSunday.AddDays(1), "Tweede Paasdag", "Easter Monday", countryCode, 1642));
             items.Add(new PublicHoliday(year, 4, kingsDay, "Koningsdag", "King's Day", countryCode));
             items.Add(new PublicHoliday(easterSunday.AddDays(39), "Hemelvaartsdag", "Ascension Day", countryCode));
             items.Add(new PublicHoliday(easterSunday.AddDays(50), "Pinksteren", "Whit Monday", countryCode));

--- a/Src/Nager.Date/PublicHolidays/NetherlandsProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/NetherlandsProvider.cs
@@ -51,8 +51,8 @@ namespace Nager.Date.PublicHolidays
             items.Add(new PublicHoliday(year, 4, kingsDay, "Koningsdag", "King's Day", countryCode));
             items.Add(new PublicHoliday(easterSunday.AddDays(39), "Hemelvaartsdag", "Ascension Day", countryCode));
             items.Add(new PublicHoliday(easterSunday.AddDays(50), "Pinksteren", "Whit Monday", countryCode));
-            items.Add(new PublicHoliday(year, 12, 25, "Eerste kerstdag", "Christmas Day", countryCode));
-            items.Add(new PublicHoliday(year, 12, 26, "Tweede kerstdag", "St. Stephen's Day", countryCode));
+            items.Add(new PublicHoliday(year, 12, 25, "Eerste Kerstdag", "Christmas Day", countryCode));
+            items.Add(new PublicHoliday(year, 12, 26, "Tweede Kerstdag", "St. Stephen's Day", countryCode));
 
             #region Liberation Day
 


### PR DESCRIPTION
> The Dutch have a two-day holiday, called Eerste Paasdag on Sunday and Tweede Paasdag on Monday (lit. First Easter Day and Second Easter Day)

https://en.wikipedia.org/wiki/Public_holidays_in_the_Netherlands

I also changed the spelling of the 2 Christmas holidays of the Netherlands. There are 2 official rules (_Het Groene Boekje_ and _Het Witte Boekje_) that may be used to determine whether both letters should be written in capital. I used the most common rule, because this looks nicer in my opinion. 