### PR TITLE
Change Austrians 10-26 to 'Nationalfeiertag'

### DIFF
--- a/Src/Nager.Date/PublicHolidays/AustriaProvider.cs
+++ b/Src/Nager.Date/PublicHolidays/AustriaProvider.cs
@@ -62,7 +62,7 @@ namespace Nager.Date.PublicHolidays
             items.Add(new PublicHoliday(easterSunday.AddDays(50), "Pfingstmontag", "Whit Monday", countryCode));
             items.Add(new PublicHoliday(easterSunday.AddDays(60), "Fronleichnam", "Corpus Christi", countryCode));
             items.Add(new PublicHoliday(year, 8, 15, "Maria Himmelfahrt", "Assumption Day", countryCode));
-            items.Add(new PublicHoliday(year, 10, 26, "Staatsfeiertag", "National Holiday", countryCode));
+            items.Add(new PublicHoliday(year, 10, 26, "Nationalfeiertag", "National Holiday", countryCode));
             items.Add(new PublicHoliday(year, 11, 1, "Allerheiligen", "All Saints' Day", countryCode));
             items.Add(new PublicHoliday(year, 12, 8, "Mariä Empfängnis", "Immaculate Conception", countryCode));
             items.Add(new PublicHoliday(year, 12, 25, "Weihnachten", "Christmas Day", countryCode));


### PR DESCRIPTION
10-26 is called Nationalfeiertag while 01-05 is called Staatsfeiertag. Source: https://en.wikipedia.org/wiki/Public_holidays_in_Austria

Thanks for the library.